### PR TITLE
Feat/quac 7 users 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,14 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Spring Security 추가
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // Jwt 관련 의존성
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // for JSON processing
 }
 
 tasks.named('test') {

--- a/src/main/java/io/quacker/common/util/JwtTokenUtil.java
+++ b/src/main/java/io/quacker/common/util/JwtTokenUtil.java
@@ -1,6 +1,5 @@
 package io.quacker.common.util;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -12,12 +11,12 @@ import java.util.Date;
 import java.util.Map;
 
 @Component
-@RequiredArgsConstructor
+//@RequiredArgsConstructor
 public class JwtTokenUtil {
 
     // 우선 하드 코딩
 //    @Value("$jwt.key")
-    private static final String SECRET_KEY = "123";
+    private static final String SECRET_KEY = "alksjdoiasnkljdbalskjdbalskjdhlakjshdljnalfgjksdbflkjshdfglksjndflkjsbgnldjkfbglskjdfbg";
     private static final long EXPIRATION = 15 * 60; // 15분
 
     private final Key key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
@@ -25,10 +24,9 @@ public class JwtTokenUtil {
     /**
      * JWT 토큰 생성 (사용자 ID, 이메일 포함)
      */
-    public String generateToken(Long userId, String username) {
+    public String generateToken(Long userId, String email, String name) {
         return Jwts.builder()
-                .setClaims(Map.of("username", username)) // email 저장
-                //TODO UUID 필요할듯
+                .setClaims(Map.of("email", email, "name", name)) // email 저장
                 .setSubject(userId.toString()) // 사용자 id 저장,
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION))
@@ -47,6 +45,19 @@ public class JwtTokenUtil {
                         .parseClaimsJwt(token)
                         .getBody()
                         .getSubject()); // sub
+    }
+    /**
+     * 비공개 claim email 사용
+     * JWT 토큰에서 사용자 email 추출
+     */
+    public String extractEmail(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJwt(token)
+                .getBody()
+                .get("email")
+                .toString();
     }
 
     /**

--- a/src/main/java/io/quacker/common/util/JwtTokenUtil.java
+++ b/src/main/java/io/quacker/common/util/JwtTokenUtil.java
@@ -17,7 +17,7 @@ public class JwtTokenUtil {
     // 우선 하드 코딩
 //    @Value("$jwt.key")
     private static final String SECRET_KEY = "alksjdoiasnkljdbalskjdbalskjdhlakjshdljnalfgjksdbflkjshdfglksjndflkjsbgnldjkfbglskjdfbg";
-    private static final long EXPIRATION = 15 * 60; // 15분
+    private static final long EXPIRATION = 15 * 60 * 60;
 
     private final Key key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
 
@@ -42,7 +42,7 @@ public class JwtTokenUtil {
         return Long.parseLong(Jwts.parserBuilder()
                         .setSigningKey(key)
                         .build()
-                        .parseClaimsJwt(token)
+                        .parseClaimsJws(token)
                         .getBody()
                         .getSubject()); // sub
     }
@@ -54,7 +54,7 @@ public class JwtTokenUtil {
         return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()
-                .parseClaimsJwt(token)
+                .parseClaimsJws(token)
                 .getBody()
                 .get("email")
                 .toString();
@@ -74,7 +74,7 @@ public class JwtTokenUtil {
         return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()
-                .parseClaimsJwt(token)
+                .parseClaimsJws(token)
                 .getBody()
                 .getExpiration() // exp
                 .before(new Date());

--- a/src/main/java/io/quacker/common/util/JwtTokenUtil.java
+++ b/src/main/java/io/quacker/common/util/JwtTokenUtil.java
@@ -1,0 +1,71 @@
+package io.quacker.common.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenUtil {
+
+    // 우선 하드 코딩
+//    @Value("$jwt.key")
+    private static final String SECRET_KEY = "123";
+    private static final long EXPIRATION = 15 * 60; // 15분
+
+    private final Key key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+
+    /**
+     * JWT 토큰 생성 (사용자 ID, 이메일 포함)
+     */
+    public String generateToken(Long userId, String username) {
+        return Jwts.builder()
+                .setClaims(Map.of("username", username)) // email 저장
+                //TODO UUID 필요할듯
+                .setSubject(userId.toString()) // 사용자 id 저장,
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * sub으로 사용자 id 사용
+     * JWT 토큰에서 사용자 ID 추출
+     */
+    public Long extractUserId(String token) {
+        return Long.parseLong(Jwts.parserBuilder()
+                        .setSigningKey(key)
+                        .build()
+                        .parseClaimsJwt(token)
+                        .getBody()
+                        .getSubject()); // sub
+    }
+
+    /**
+     * 토큰이 유효한지, 만료되지 않았는지 검증
+     */
+    public boolean validateToken(String token, Long userId) {
+        return extractUserId(token).equals(userId) && !isTokenExpired(token);
+    }
+
+    /**
+     * 토큰 만료 확인
+     */
+    private boolean isTokenExpired(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJwt(token)
+                .getBody()
+                .getExpiration() // exp
+                .before(new Date());
+    }
+}

--- a/src/main/java/io/quacker/domain/user/controller/UserAuthController.java
+++ b/src/main/java/io/quacker/domain/user/controller/UserAuthController.java
@@ -1,0 +1,38 @@
+package io.quacker.domain.user.controller;
+
+import io.quacker.domain.user.dto.UserCreateDto;
+import io.quacker.domain.user.dto.UserLoginDto;
+import io.quacker.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/auth")
+public class UserAuthController {
+
+    private final UserService userService;
+
+    /**
+     * 로그인 엔드포인트
+     * @param userLoginDto
+     * @return
+     */
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody UserLoginDto userLoginDto) {
+//        userService.login(userCreateDto);
+        return ResponseEntity.status(HttpStatus.OK).body(userService.login(userLoginDto));
+    }
+
+    /**
+     * 가입 엔드포인트
+     * @param userCreateDto
+     * @return JWT 토큰 반환
+     */
+    @PostMapping("/join")
+    public ResponseEntity<?> join(@RequestBody UserCreateDto userCreateDto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(userService.join(userCreateDto));
+    }
+}

--- a/src/main/java/io/quacker/domain/user/controller/UserAuthController.java
+++ b/src/main/java/io/quacker/domain/user/controller/UserAuthController.java
@@ -4,6 +4,7 @@ import io.quacker.domain.user.dto.UserCreateDto;
 import io.quacker.domain.user.dto.UserLoginDto;
 import io.quacker.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/io/quacker/domain/user/controller/UserController.java
+++ b/src/main/java/io/quacker/domain/user/controller/UserController.java
@@ -1,0 +1,8 @@
+package io.quacker.domain.user.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+
+}

--- a/src/main/java/io/quacker/domain/user/controller/UserController.java
+++ b/src/main/java/io/quacker/domain/user/controller/UserController.java
@@ -1,8 +1,27 @@
 package io.quacker.domain.user.controller;
 
+import io.quacker.domain.user.dto.CustomUserDetails;
+import io.quacker.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
+@RequiredArgsConstructor
 @RestController
+@RequestMapping("/api/v1/users")
 public class UserController {
 
+    private final UserService userService;
+
+    @PatchMapping("/visibility")
+    public ResponseEntity<?> toggleVisibility(@AuthenticationPrincipal CustomUserDetails customUserDetails){
+        userService.toggleVisibility(customUserDetails);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("result", true));
+    }
 }

--- a/src/main/java/io/quacker/domain/user/dao/UserRepositoy.java
+++ b/src/main/java/io/quacker/domain/user/dao/UserRepositoy.java
@@ -1,0 +1,16 @@
+package io.quacker.domain.user.dao;
+
+
+import io.quacker.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepositoy extends JpaRepository<User, Long> {
+
+    public boolean existsByEmail(String email);
+
+    public Optional<User> findByEmail(String email);
+}

--- a/src/main/java/io/quacker/domain/user/dto/CustomUserDetails.java
+++ b/src/main/java/io/quacker/domain/user/dto/CustomUserDetails.java
@@ -1,0 +1,49 @@
+package io.quacker.domain.user.dto;
+
+import io.quacker.domain.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public record CustomUserDetails(
+        User user
+) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/src/main/java/io/quacker/domain/user/dto/UserCreateDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserCreateDto.java
@@ -11,20 +11,5 @@ public record UserCreateDto (
         String name,
         String bio,
         String avatarImageUrl,
-        boolean verified,
         boolean isPrivate
-) {
-
-    //Todo : Entity
-    public User toUserWtihHashedPassword(String hashedPw) {
-        return User.builder()
-                .email(email)
-                .password(hashedPw)
-                .name(name)
-                .bio(bio)
-                .avatarImageUrl(avatarImageUrl)
-                .verified(verified)
-                .isPrivate(isPrivate)
-                .build();
-    }
-}
+) {}

--- a/src/main/java/io/quacker/domain/user/dto/UserCreateDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserCreateDto.java
@@ -1,0 +1,30 @@
+package io.quacker.domain.user.dto;
+
+import io.quacker.domain.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record UserCreateDto (
+        String email,
+        String password,
+        String confirmPassword,
+        String name,
+        String bio,
+        String avatarImageUrl,
+        boolean verified,
+        boolean isPrivate
+) {
+
+    //Todo : Entity
+    public User toUserWtihHashedPassword(String hashedPw) {
+        return User.builder()
+                .email(email)
+                .password(hashedPw)
+                .name(name)
+                .bio(bio)
+                .avatarImageUrl(avatarImageUrl)
+                .verified(verified)
+                .isPrivate(isPrivate)
+                .build();
+    }
+}

--- a/src/main/java/io/quacker/domain/user/dto/UserDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserDto.java
@@ -1,0 +1,39 @@
+package io.quacker.domain.user.dto;
+
+import io.quacker.domain.post.entity.Post;
+import io.quacker.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+public record UserDto(
+
+        String email,
+
+        String name,
+
+        String bio,
+
+        String avatarImageUrl,
+
+        boolean verified,
+
+        boolean isLocked, // 정지
+
+        boolean isPrivate, // 계정 공개
+
+        List<Post> posts
+){
+    public static UserDto from(User user) {
+        return UserDto.builder()
+                .build();
+    }
+
+    public static UserDto from(UserCreateDto dto) {
+        return UserDto.builder()
+                .build();
+    }
+}

--- a/src/main/java/io/quacker/domain/user/dto/UserLoginDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserLoginDto.java
@@ -1,0 +1,6 @@
+package io.quacker.domain.user.dto;
+
+public record UserLoginDto(
+        String email,
+        String password
+) {}

--- a/src/main/java/io/quacker/domain/user/dto/UserUpdateDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserUpdateDto.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Builder
-public record UserDto(
+public record UserUpdateDto(
 
         String email,
 
@@ -27,15 +27,5 @@ public record UserDto(
 
         List<Post> posts
 ){
-    public static UserDto from(User user) {
-        return UserDto.builder()
-                .email(user.getEmail())
-                .name(user.getName())
-                .bio(user.getBio())
-                .avatarImageUrl(user.getAvatarImageUrl())
-                .verified(user.isVerified())
-                .isLocked(user.isLocked())
-                .isPrivate(user.isPrivate())
-                .build();
-    }
+
 }

--- a/src/main/java/io/quacker/domain/user/entity/User.java
+++ b/src/main/java/io/quacker/domain/user/entity/User.java
@@ -5,6 +5,7 @@ import io.quacker.domain.comment.entity.Comment;
 import io.quacker.domain.post.entity.Post;
 import io.quacker.domain.postlike.entity.PostLike;
 import io.quacker.domain.postmention.entity.PostMention;
+import io.quacker.domain.user.dto.UserCreateDto;
 import io.quacker.domain.userfollowing.entitty.UserFollowing;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -67,5 +68,18 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user")
     private List<PostLike> likes = new ArrayList<>();
+
+
+    public User from(UserCreateDto userCreateDto) {
+        return User.builder()
+                .email(userCreateDto.email())
+                .password(userCreateDto.password())
+                .name(userCreateDto.name())
+                .bio(userCreateDto.bio())
+                .avatarImageUrl(userCreateDto.avatarImageUrl())
+                .verified(userCreateDto.verified())
+                .isPrivate(userCreateDto.isPrivate())
+                .build();
+    }
 }
 

--- a/src/main/java/io/quacker/domain/user/entity/User.java
+++ b/src/main/java/io/quacker/domain/user/entity/User.java
@@ -69,17 +69,27 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user")
     private List<PostLike> likes = new ArrayList<>();
 
+    public void updateVisibility(boolean isPrivate) {
+        this.isPrivate = isPrivate;
+    }
 
-    public User from(UserCreateDto userCreateDto) {
+    public static User fromCreateDtoWithHashedPassword(UserCreateDto userCreateDto, String hashedPw) {
         return User.builder()
                 .email(userCreateDto.email())
-                .password(userCreateDto.password())
+                .password(hashedPw)
                 .name(userCreateDto.name())
                 .bio(userCreateDto.bio())
                 .avatarImageUrl(userCreateDto.avatarImageUrl())
-                .verified(userCreateDto.verified())
                 .isPrivate(userCreateDto.isPrivate())
                 .build();
+    }
+
+    public void updateProfile(String name, String bio, String avatarImageUrl, boolean isLocked, boolean isPrivate) {
+        this.name = name;
+        this.bio = bio;
+        this.avatarImageUrl = avatarImageUrl;
+        this.isLocked = isLocked;
+        this.isPrivate = isPrivate;
     }
 }
 

--- a/src/main/java/io/quacker/domain/user/service/CustomUserDetailsService.java
+++ b/src/main/java/io/quacker/domain/user/service/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+package io.quacker.domain.user.service;
+
+import io.quacker.domain.user.dao.UserRepositoy;
+import io.quacker.domain.user.dto.CustomUserDetails;
+import io.quacker.domain.user.entity.User;
+import io.quacker.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepositoy userRepositoy;
+
+    /**
+     * loaduserByEmail
+     * @param email
+     */
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepositoy.findByEmail(email)
+                //TODO : 에러 정의
+                .orElseThrow(()-> new CustomException("Invaild", 500));
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/io/quacker/domain/user/service/UserService.java
+++ b/src/main/java/io/quacker/domain/user/service/UserService.java
@@ -1,0 +1,118 @@
+package io.quacker.domain.user.service;
+
+import io.quacker.common.util.JwtTokenUtil;
+import io.quacker.domain.user.dao.UserRepositoy;
+import io.quacker.domain.user.dto.UserLoginDto;
+import io.quacker.domain.user.dto.UserCreateDto;
+import io.quacker.domain.user.dto.UserDto;
+import io.quacker.domain.user.entity.User;
+import io.quacker.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final String emailRegex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenUtil jwtTokenUtil;
+    private final UserRepositoy userRepositoy;
+
+    /**
+     * REQ_002	회원가입
+     * 생성 성공 시에 생성된 userDto 반환
+     * @param dto, UserCreadentialDto
+     * @Return UserDto
+     */
+    public UserDto join(UserCreateDto dto) {
+
+        String email = dto.email();
+        String rawPw = dto.password();
+        String rawConfirmPw = dto.confirmPassword();
+
+        /*
+         *  이메일 유효 검사 추가 할 것
+         */
+
+        if (!rawPw.equals(rawConfirmPw)) {
+            throw new CustomException("Invalid password", 500); //ToDo: 로그인 실패 객체 정의할 것
+        }
+        if (!userRepositoy.existsByEmail(email)) {
+            throw new CustomException("Email exists", 500); //ToDo: 로그인 실패 객체 정의할 것
+        }
+
+
+        User user = dto.toUserWtihHashedPassword(passwordEncoder.encode(rawPw));
+
+        try {
+            User result = userRepositoy.save(user);
+            return UserDto.from(result);
+        } catch (Exception e){
+            throw new CustomException("Failed to save user", 500); //ToDo: 저장 실패 객체 정의할 것
+        }
+    }
+
+    /**
+     * REQ_001	로그인
+     * 로그인 성공시 정보를 반환.
+     * @return String, 토큰 발급
+     */
+    public String login(UserLoginDto dto) {
+
+        String email = dto.email();
+        String rawPw = dto.password();
+
+        User user = userRepositoy.findByEmail(email)
+                .orElseThrow(() -> new CustomException("", 500));
+
+        String hashedPw = user.getPassword();
+
+        if (!passwordEncoder.matches(rawPw, hashedPw)) {
+            throw new CustomException("Invalid password", 500); //ToDo: 로그인 실패 객체 정의할 것
+        }
+
+        return jwtTokenUtil.generateToken(user.getId(), user.getEmail(), user.getName());
+    }
+
+    /**
+     * REQ_003	회원 탈퇴 요청
+     */
+    public void withDraw() {}
+
+    /**
+     * REQ_013	공개여부 토글
+     */
+    public void setPublic() {}
+
+    /**
+     * REQ_004	회원 복구
+     */
+    public void restoreUser() {}
+
+    /**
+     * REQ_005	비밀번호 재설정
+     */
+    public void resetPassword() {
+
+    }
+
+    /**
+     * REQ_006	아이디 찾기
+     */
+    public void findUser() {
+
+    }
+
+    /*
+    REQ_007	아이디 중복 확인 기능
+    REQ_008	이메일 중복 확인 기능
+    REQ_009	로그아웃
+    REQ_010	멘션
+    REQ_011	프로필 조회
+    REQ_012	프로필 수정
+    REQ_013	공개여부 토글
+
+     */
+}

--- a/src/main/java/io/quacker/domain/user/service/UserService.java
+++ b/src/main/java/io/quacker/domain/user/service/UserService.java
@@ -2,15 +2,17 @@ package io.quacker.domain.user.service;
 
 import io.quacker.common.util.JwtTokenUtil;
 import io.quacker.domain.user.dao.UserRepositoy;
-import io.quacker.domain.user.dto.UserLoginDto;
-import io.quacker.domain.user.dto.UserCreateDto;
-import io.quacker.domain.user.dto.UserDto;
+import io.quacker.domain.user.dto.*;
 import io.quacker.domain.user.entity.User;
 import io.quacker.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -39,12 +41,11 @@ public class UserService {
         if (!rawPw.equals(rawConfirmPw)) {
             throw new CustomException("Invalid password", 500); //ToDo: 로그인 실패 객체 정의할 것
         }
-        if (!userRepositoy.existsByEmail(email)) {
+        if (userRepositoy.existsByEmail(email)) {
             throw new CustomException("Email exists", 500); //ToDo: 로그인 실패 객체 정의할 것
         }
 
-
-        User user = dto.toUserWtihHashedPassword(passwordEncoder.encode(rawPw));
+        User user = User.fromCreateDtoWithHashedPassword(dto, passwordEncoder.encode(rawPw));
 
         try {
             User result = userRepositoy.save(user);
@@ -79,7 +80,7 @@ public class UserService {
     /**
      * REQ_003	회원 탈퇴 요청
      */
-    public void withDraw() {}
+    public void requestWithdraw() {}
 
     /**
      * REQ_013	공개여부 토글
@@ -100,19 +101,72 @@ public class UserService {
 
     /**
      * REQ_006	아이디 찾기
+     * 이메일 찾기
+     * 가입한 이메일로 메시지 발솔
      */
-    public void findUser() {
+    public void findEmail() {}
 
+    /**
+     * REQ_007	아이디 중복 확인 기능
+     */
+    public boolean checkDuplicateEmail() {return false;}
+
+    /**
+     * REQ_008	이메일 중복 확인 기능
+     */
+    public boolean checkDuplicateUsername() {return false;}
+
+    /**
+     * REQ_011	프로필 조회
+     */
+    public UserDto getUserById(Long userId) {
+        return UserDto.from(userRepositoy.findById(userId)
+                .orElseThrow(() -> new CustomException("유저를 찾을 수 없음", 404)));
     }
 
-    /*
-    REQ_007	아이디 중복 확인 기능
-    REQ_008	이메일 중복 확인 기능
-    REQ_009	로그아웃
-    REQ_010	멘션
-    REQ_011	프로필 조회
-    REQ_012	프로필 수정
-    REQ_013	공개여부 토글
-
+    /**
+     * REQ_012	프로필 수정
      */
+    @Transactional
+    public UserDto updateUserProfile(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            UserUpdateDto dto
+    ) {
+        User user = customUserDetails.user();
+        user.updateProfile(
+                dto.name(),
+                dto.bio(),
+                dto.avatarImageUrl(),
+                dto.isLocked(),
+                dto.isPrivate()
+        );
+        return UserDto.from(user);
+    }
+
+   /**
+    * REQ_013	공개여부 토글
+    */
+   @Transactional
+   public void toggleVisibility(
+           CustomUserDetails customUserDetails
+   ) {
+       User user = customUserDetails.user();
+       user.updateVisibility(!user.isPrivate());
+   }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/io/quacker/global/config/SecurityConfig.java
+++ b/src/main/java/io/quacker/global/config/SecurityConfig.java
@@ -35,8 +35,11 @@ public class SecurityConfig {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))  // iframe 허용하기 위하여
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                                .requestMatchers("/api/v1/auth/login", "/api/v1/auth/join").permitAll()
+                                .requestMatchers("/h2-console/**").permitAll() // H2 Console 접근 허용                                .anyRequest().authenticated()
+                                .anyRequest().permitAll()
                 )
                 .authenticationProvider(jwtTokenAuthenticationProvider)
                 .addFilterBefore(jwtTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/io/quacker/global/config/SecurityConfig.java
+++ b/src/main/java/io/quacker/global/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package io.quacker.global.config;
+
+import io.quacker.common.util.JwtTokenUtil;
+import io.quacker.domain.user.service.CustomUserDetailsService;
+import io.quacker.global.security.JwtTokenAuthenticationFilter;
+import io.quacker.global.security.JwtTokenAuthenticationProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenAuthenticationFilter jwtTokenAuthenticationFilter;
+
+    // BCrypt 인코더 추가
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // 시큐리티 체인 설정
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtTokenAuthenticationProvider jwtTokenAuthenticationProvider) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .authenticationProvider(jwtTokenAuthenticationProvider)
+                .addFilterBefore(jwtTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/io/quacker/global/security/JwtTokenAuthenticationFilter.java
+++ b/src/main/java/io/quacker/global/security/JwtTokenAuthenticationFilter.java
@@ -1,0 +1,68 @@
+package io.quacker.global.security;
+
+import io.quacker.common.util.JwtTokenUtil;
+import io.quacker.domain.user.dto.CustomUserDetails;
+import io.quacker.domain.user.service.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtTokenUtil jwtTokenUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if ( authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 헤더 파싱
+        String token = authorizationHeader.substring(7);
+//        Long userId = jwtTokenUtil.extractUserId(token);
+        String email = jwtTokenUtil.extractEmail(token);
+
+        // 이메일이 존재하지않고 현재 SecurityContext에 인증 정보가 없는 경우 새로 토큰 발급
+        if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(email);
+
+            // 유효한 토근인가.
+            if (jwtTokenUtil.validateToken(token, userDetails.user().getId())) {
+                UsernamePasswordAuthenticationToken authToken =
+                        new UsernamePasswordAuthenticationToken(userDetails,
+                                null, // jwt, 생략
+                                userDetails.getAuthorities());
+
+
+                // 현재 요청 정보를 인증 토큰에 설정
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                // SecurityContext에 인증 정보 설정
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+
+        // done
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/io/quacker/global/security/JwtTokenAuthenticationProvider.java
+++ b/src/main/java/io/quacker/global/security/JwtTokenAuthenticationProvider.java
@@ -1,0 +1,41 @@
+package io.quacker.global.security;
+
+import io.quacker.domain.user.service.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenAuthenticationProvider implements AuthenticationProvider {
+
+    private final PasswordEncoder passwordEncoder;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String email = authentication.getName();
+        String rawPw = authentication.getCredentials().toString();
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+        if (!passwordEncoder.matches(rawPw, userDetails.getPassword())) {
+            throw new BadCredentialsException("Invalid credentials");
+        }
+
+        return new UsernamePasswordAuthenticationToken(
+                userDetails,
+                rawPw,
+                userDetails.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}
+


### PR DESCRIPTION
### 📄 작업 내용

User JWT인증, 회원가입, 로그인, 테스트용 엔드포인트 제작

### 🌠 스크린샷

![image](https://github.com/user-attachments/assets/0a88e1b0-1d62-45b4-9570-9719b0aadaf2)
![image](https://github.com/user-attachments/assets/1e01d95f-044a-4f57-afc5-4833f7cf2492)
![image](https://github.com/user-attachments/assets/fca57430-323d-4c78-99e3-1207bd43cd04)


### 📌 이슈 링크

https://quacker25.atlassian.net/browse/QUAC-7?atlOrigin=eyJpIjoiMTc1ZDk5NGFhZTI3NDhmMTgzNTA4NzYwNzIyNzZiYzUiLCJwIjoiaiJ9


### 📚 앞으로의 과제

- 예외처리와 나머지 기능구현이 필요
- JWT유틸 리펙토링이 필요
- 리프레시 토큰 적용
- UserAuthController와 UserController를 분리한게 타당한가 생각
