### PR TITLE
feat/QUAC-7-Users-인증 

### DIFF
--- a/src/main/java/io/quacker/common/dao/DefaultCacheRepository.java
+++ b/src/main/java/io/quacker/common/dao/DefaultCacheRepository.java
@@ -1,0 +1,18 @@
+package io.quacker.common.dao;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+public interface DefaultCacheRepository {
+
+    boolean exisits(String key);
+
+    Optional<String> get(String key);
+
+    List<Object> getAllKeys();
+
+    String setex(String key, Date exp, String value);
+
+    String delete(String key);
+}

--- a/src/main/java/io/quacker/common/dao/JwtRepository.java
+++ b/src/main/java/io/quacker/common/dao/JwtRepository.java
@@ -1,0 +1,4 @@
+package io.quacker.common.dao;
+
+public interface JwtRepository extends DefaultCacheRepository {
+}

--- a/src/main/java/io/quacker/common/dao/UserDeletionRepository.java
+++ b/src/main/java/io/quacker/common/dao/UserDeletionRepository.java
@@ -1,0 +1,4 @@
+package io.quacker.common.dao;
+
+public interface UserDeletionRepository extends DefaultCacheRepository{
+}

--- a/src/main/java/io/quacker/common/util/JwtTokenUtil.java
+++ b/src/main/java/io/quacker/common/util/JwtTokenUtil.java
@@ -1,39 +1,76 @@
 package io.quacker.common.util;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
 import java.util.Date;
 import java.util.Map;
+import java.util.UUID;
 
 @Component
 public class JwtTokenUtil {
 
-    private final Long expiration;
+    private final Long accessTokenExpiration;
+    private final Long refreshTokenExpiration;
     private final Key key;
 
     public JwtTokenUtil(
             @Value("${jwt.secret}") String secretKey,
-            @Value("${jwt.expiration}") long expiration
+            @Value("${jwt.expiration.access}") long accessTokenExpiration,
+            @Value("${jwt.expiration.refresh}") long refreshTokenExpiration
     ) {
         this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
-        this.expiration = expiration;
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
     }
 
     /**
-     * JWT 토큰 생성 (사용자 ID, 이메일 포함)
+     * Access JWT 토큰 생성 (사용자 ID, 이메일 포함)
+     * @param userId, 고유식별자
+     * @param email, 참고
+     * @param name, 참고
+     * @return String, 접근토큰
      */
-    public String generateToken(Long userId, String email, String name) {
+    public String generateAccessToken(Long userId, String email, String name) {
+        String jwtId = UUID.randomUUID().toString();
         return Jwts.builder()
                 .setClaims(Map.of("email", email, "name", name)) // email 저장
                 .setSubject(userId.toString()) // 사용자 id 저장,
+                .setId(jwtId)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+    public String generateAccess2Token(Long userId, String email, String name) {
+        String jwtId = UUID.randomUUID().toString();
+        return Jwts.builder()
+                .setClaims(Map.of("email", email, "name", name)) // email 저장
+                .setSubject(userId.toString()) // 사용자 id 저장,
+                .setId(jwtId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 3*1000))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * Access JWT 토큰 생성 (사용자 ID, 이메일 포함)
+     * @param userId, 고유식별자 sub
+     * @return String, 접근토큰
+     */
+    public String generateRefreshToken(Long userId) {
+        String jwtId = UUID.randomUUID().toString();
+        return Jwts.builder()
+                .setSubject(userId.toString()) // 사용자 id 저장,
+                .setId(jwtId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
@@ -65,22 +102,48 @@ public class JwtTokenUtil {
     }
 
     /**
-     * 토큰이 유효한지, 만료되지 않았는지 검증
+     * JWT 토큰에서 jwi 추출
      */
-    public boolean validateToken(String token, Long userId) {
+    public String extractId(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getId();
+    }
+
+    public Date extractExpiration(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+    }
+
+    /**
+     * 접근 토큰이 유효한지, 만료되지 않았는지 검증
+     */
+    public boolean validateAccessToken(String token, Long userId) {
         return extractUserId(token).equals(userId) && !isTokenExpired(token);
     }
 
     /**
      * 토큰 만료 확인
      */
-    private boolean isTokenExpired(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .getExpiration() // exp
-                .before(new Date());
+    public boolean isTokenExpired(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getExpiration() // exp
+                    .before(new Date());
+        } catch (ExpiredJwtException e) {
+            return true;
+        }
     }
+
 }

--- a/src/main/java/io/quacker/domain/auth/dao/MemoryJwtRepository.java
+++ b/src/main/java/io/quacker/domain/auth/dao/MemoryJwtRepository.java
@@ -25,6 +25,11 @@ public class MemoryJwtRepository implements JwtRepository {
     }
 
     @Override
+    public List<Object> getAllKeys() {
+        return Arrays.asList(mem.keySet().toArray());
+    }
+
+    @Override
     public String setex(String key, Date exp, String value) {
         var item = mem.put(key, JwtItem.builder()
                 .exp(exp)

--- a/src/main/java/io/quacker/domain/auth/dao/MemoryJwtRepository.java
+++ b/src/main/java/io/quacker/domain/auth/dao/MemoryJwtRepository.java
@@ -1,0 +1,51 @@
+package io.quacker.domain.auth.dao;
+
+import io.quacker.common.dao.JwtRepository;
+import io.quacker.domain.auth.dto.JwtItem;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Slf4j
+@Repository
+public class MemoryJwtRepository implements JwtRepository {
+
+    //TODO 재발급 limit을 위한 카운트?
+    private final Map<String, JwtItem> mem = new HashMap<>();
+
+    @Override
+    public boolean exisits(String key) {
+        return mem.get(key) != null;
+    }
+
+    @Override
+    public Optional<String> get(String key) {
+        return Optional.ofNullable(mem.get(key).getTokenId().toString());
+    }
+
+    @Override
+    public String setex(String key, Date exp, String value) {
+        var item = mem.put(key, JwtItem.builder()
+                .exp(exp)
+                .tokenId(value)
+                .build());
+
+        return item.getTokenId().toString();
+    }
+
+    @Override
+    public String delete(String key) {
+        return mem.remove(key).getTokenId().toString();
+    }
+
+    public void deleteExpiredItem() {
+//        log.info("Current cnt : " + mem.size());
+//        mem.entrySet().removeIf(entry->entry.getValue().isBanned());
+        Date now = new Date();
+        mem.entrySet().removeIf(entry-> {
+            log.info("["+ entry.getKey() + "]" + "   만료시간: "+  entry.getValue().getExp().toString());
+            return entry.getValue().getExp().before(now);
+        });
+    }
+}

--- a/src/main/java/io/quacker/domain/auth/dto/JwtItem.java
+++ b/src/main/java/io/quacker/domain/auth/dto/JwtItem.java
@@ -1,0 +1,23 @@
+package io.quacker.domain.auth.dto;
+
+import lombok.Builder;
+
+import java.util.Date;
+
+/**
+ * 토큰 리스트에 저장되기 위한 인터페이스입니다.
+ * 토큰 객체가 아니라. 토큰의 일부 정보를 저장합니다.
+ */
+@Builder
+public class JwtItem {
+
+    private Object tokenId;
+    private Date exp;
+
+    public Object getTokenId() { return tokenId; }
+
+    public Date getExp() { return exp; }
+
+}
+
+

--- a/src/main/java/io/quacker/domain/auth/dto/JwtTokens.java
+++ b/src/main/java/io/quacker/domain/auth/dto/JwtTokens.java
@@ -1,0 +1,9 @@
+package io.quacker.domain.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record JwtTokens(
+        String accessToken,
+        String refreshToken
+){}

--- a/src/main/java/io/quacker/domain/auth/service/JwtBlacklistService.java
+++ b/src/main/java/io/quacker/domain/auth/service/JwtBlacklistService.java
@@ -1,0 +1,63 @@
+package io.quacker.domain.auth.service;
+
+import io.quacker.common.dao.JwtRepository;
+import io.quacker.common.util.JwtTokenUtil;
+import io.quacker.common.dao.DefaultCacheRepository;
+import io.quacker.domain.auth.dao.MemoryJwtRepository;
+import io.quacker.domain.auth.dto.JwtItem;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * 리프레시 토큰 블랙리스트 서비스입니다.
+ */
+@Slf4j
+@Service
+@EnableScheduling
+@RequiredArgsConstructor
+public class JwtBlacklistService {
+
+    private final JwtRepository jwtRepository;
+    private final JwtTokenUtil jwtTokenUtil;
+
+    /**
+     * 토큰이 리스트에 포함되며, 만료 되지않았고, 유효한지 확인합니다.
+     * @param token
+     * @return 유효성
+     */
+    public boolean validateToken(String token) {
+        String key = jwtTokenUtil.extractId(token);
+        if (jwtRepository.exisits(key)){
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * 토큰을 리스트에 등록합니다.
+     * @param token
+     */
+    public void registerToken(String token) {
+        String key = jwtTokenUtil.extractId(token);
+        log.info(key);
+        jwtRepository.setex(
+                key,
+                jwtTokenUtil.extractExpiration(token),
+                jwtTokenUtil.extractUserId(token).toString()
+        );
+    }
+
+    /**
+     * 배치나, 스케줄 추가하여 만료토큰 정기적으로 삭제?
+     * 현시간 부로 만료된 토큰을 모두 제거
+     * 10초마다 삭제
+     */
+    @Scheduled(fixedDelay = 10000)
+    public void deleteExpiratedJwtItem() {
+        ((MemoryJwtRepository) jwtRepository).deleteExpiratedItem();
+    }
+}

--- a/src/main/java/io/quacker/domain/auth/service/JwtBlacklistService.java
+++ b/src/main/java/io/quacker/domain/auth/service/JwtBlacklistService.java
@@ -5,11 +5,17 @@ import io.quacker.common.util.JwtTokenUtil;
 import io.quacker.common.dao.DefaultCacheRepository;
 import io.quacker.domain.auth.dao.MemoryJwtRepository;
 import io.quacker.domain.auth.dto.JwtItem;
+import io.quacker.domain.user.dto.DeletionItem;
+import io.quacker.domain.user.entity.User;
+import io.quacker.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import java.util.Date;
 
 /**
  * 리프레시 토큰 블랙리스트 서비스입니다.
@@ -58,6 +64,6 @@ public class JwtBlacklistService {
      */
     @Scheduled(fixedDelay = 10000)
     public void deleteExpiratedJwtItem() {
-        ((MemoryJwtRepository) jwtRepository).deleteExpiratedItem();
+        ((MemoryJwtRepository) jwtRepository).deleteExpiredItem();
     }
 }

--- a/src/main/java/io/quacker/domain/post/repository/PostRepository.java
+++ b/src/main/java/io/quacker/domain/post/repository/PostRepository.java
@@ -1,7 +1,0 @@
-package io.quacker.domain.post.repository;
-
-import io.quacker.domain.post.entity.Post;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PostRepository extends JpaRepository<Post, Long> {
-} 

--- a/src/main/java/io/quacker/domain/user/controller/UserAuthController.java
+++ b/src/main/java/io/quacker/domain/user/controller/UserAuthController.java
@@ -1,25 +1,27 @@
 package io.quacker.domain.user.controller;
 
+import io.quacker.domain.auth.dto.JwtTokens;
 import io.quacker.domain.user.dto.UserCreateDto;
 import io.quacker.domain.user.dto.UserLoginDto;
 import io.quacker.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/auth")
 public class UserAuthController {
 
     private final UserService userService;
+//    private @Value("${jwt.expiration.}") int cookieExpiration; // 7 * 24 * 60 * 60
 
     /**
      * 로그인 엔드포인트
@@ -32,12 +34,33 @@ public class UserAuthController {
         if (errors.hasErrors()) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors.toString());
         }
-//        userService.login(userCreateDto);
-        return ResponseEntity.status(HttpStatus.OK).body(userService.login(userLoginDto));
+        JwtTokens tokens = userService.login(userLoginDto);
+        // 쿠키 생성
+        ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", tokens.accessToken())
+                .httpOnly(true)
+//                .secure(true)  // HTTPS에서만 전송
+                .path("/")     // 쿠키 경로 설정
+                .maxAge(15 * 60) // 쿠키 만료시간 (7일)
+//                .sameSite("Strict") // Cross-site 요청 제한
+                .build();
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", tokens.refreshToken())
+                .httpOnly(true)
+//                .secure(true)
+                .path("/api/v1/auth")
+                .maxAge(14 * 24 * 60 * 60)
+//                .sameSite("Strict")
+                .build();
+
+
+        // ResponseEntity에 헤더와 응답 본문 설정
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .build();
     }
 
     /**
-     * 가입 엔드포인트
+     * 가입
      * @param userCreateDto
      * @param errors
      * @return ResponseEntity
@@ -48,5 +71,63 @@ public class UserAuthController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors.toString());
         }
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.join(userCreateDto));
+    }
+
+    /**
+     * 리프레시 토큰으로 액세스토큰 재발급
+     * @param refreshToken
+     * @return
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(@CookieValue(value = "refreshToken") String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+        JwtTokens tokens = userService.refresh(refreshToken);
+        ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", tokens.accessToken())
+                .httpOnly(true)
+                .path("/")
+                .maxAge(15 * 60) // 쿠키 만료시간 (7일)
+                .build();
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", tokens.refreshToken())
+                .httpOnly(true)
+                .path("/api/v1/auth")
+                .maxAge(14 * 24 * 60 * 60)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .build();
+    }
+
+    /**
+     * 소유한 토큰 모두 만료 및 쿠키 삭제
+     * @return
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(
+            @CookieValue(value = "accessToken") String accessToken,
+            @CookieValue(value = "refreshToken") String refreshToken
+
+    ) {
+        userService.logout(accessToken, refreshToken);
+
+        ResponseCookie access = ResponseCookie.from("accessToken", "")
+                .path("/")
+                .httpOnly(true)
+                .maxAge(0)
+                .build();
+
+        ResponseCookie refresh = ResponseCookie.from("refreshToken", "")
+                .path("/")
+                .httpOnly(true)
+                .maxAge(0)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, access.toString())
+                .header(HttpHeaders.SET_COOKIE, refresh.toString())
+                .body("로그아웃성공");
     }
 }

--- a/src/main/java/io/quacker/domain/user/controller/UserController.java
+++ b/src/main/java/io/quacker/domain/user/controller/UserController.java
@@ -1,14 +1,13 @@
 package io.quacker.domain.user.controller;
 
 import io.quacker.domain.user.dto.CustomUserDetails;
+import io.quacker.domain.user.dto.UserCreateDto;
 import io.quacker.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -23,5 +22,66 @@ public class UserController {
     public ResponseEntity<?> toggleVisibility(){
         userService.toggleVisibility();
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("result", true));
+    }
+
+    //삭제 "요청"
+    @PostMapping("/delete")
+    public ResponseEntity<?> requestDelete(@PathVariable("userId") Long userId) {
+        //Todo : RESTful 한 설계이어야하나? 리소스 식별자가 필요한가.
+        return ResponseEntity.status(HttpStatus.OK).body(userService.requestDeletion());
+    }
+
+    //삭제 취소
+    @PostMapping("/abort")
+    public ResponseEntity<?> abort(@PathVariable("userId") Long userId) {
+        //Todo : RESTful 한 설계이어야하나?
+        userService.abortUserDeletion();
+        return ResponseEntity.status(HttpStatus.OK).body("done");
+    }
+
+    //힌트로 이메일 찾기
+    @GetMapping("/hint")
+    public ResponseEntity<?> getEmailhint(@RequestBody String hint) {
+        return ResponseEntity.status(HttpStatus.OK).body(userService.getEmailByHint(hint));
+    }
+
+    // 이메일 중복 확인?
+    @GetMapping("/email/{email}")
+    public ResponseEntity<?> duplicateEmail(@PathVariable("email") String email) {
+        return ResponseEntity.status(HttpStatus.OK).body(userService.checkDuplicateEmail(email));
+    }
+
+    // 사용자 이름 중복 확인
+    @GetMapping("/username/{username}")
+    public ResponseEntity<?> duplicateUsername(@PathVariable("username") String username) {
+        return ResponseEntity.status(HttpStatus.OK).body(userService.checkDuplicateUsername(username));
+    }
+
+    // 인증 세션 생성
+    @PostMapping("/session")
+    public ResponseEntity<?> createSession(@RequestBody String email) {
+        // 1. 이메일 중복확인
+        // 2. 이메일기반으로 세션 생성(유효 15분)
+        // 3. 이메일로 인증하고 인증성공시 유효한 세선 전환
+        //ToDo 생성된 세션의 식별자(세션id)와 생성시간 만료시간
+        return ResponseEntity.status(HttpStatus.CREATED).body("created");
+    }
+
+    // 사용자 비밀번호 변경(인증 세션 필요)
+    @PutMapping("/reset-password")
+    public ResponseEntity<?> resetPassword(@RequestBody UserCreateDto userCreateDto) {
+        // 1. 세션 인증 확인
+        // 2. 세션종료, 세션 삭제
+        userService.resetPassword(userCreateDto);
+        //TODO : 성공 response dto?
+        return ResponseEntity.status(HttpStatus.OK).body("done");
+    }
+
+    @PutMapping("/session/verify")
+    public ResponseEntity<?> verifyEmail(@RequestBody UserCreateDto userCreateDto) {
+        // 1. 생성시간이 만료된 세션을 삭제
+        // 2. 인증 성공시 세션 상태를 verify로 변경
+        // TODO : join api에 verify 하고 성공시에 user.verified =true로 변경하여 save할 것
+        return null;
     }
 }

--- a/src/main/java/io/quacker/domain/user/dao/MemoryUserDeletionRepository.java
+++ b/src/main/java/io/quacker/domain/user/dao/MemoryUserDeletionRepository.java
@@ -1,0 +1,39 @@
+package io.quacker.domain.user.dao;
+
+import io.quacker.common.dao.UserDeletionRepository;
+import io.quacker.domain.user.dto.DeletionItem;
+
+import java.util.*;
+
+public class MemoryUserDeletionRepository implements UserDeletionRepository {
+
+    private final Map<String, DeletionItem> mem = new HashMap<>();
+
+    @Override
+    public boolean exisits(String key) { return mem.containsKey(key); }
+
+    @Override
+    public Optional<String> get(String key) {
+        return Optional.ofNullable(mem.get(key).getUserId().toString());
+    }
+
+    @Override
+    public List<Object> getAllKeys() {
+        return Arrays.asList(mem.keySet().toArray());
+    }
+
+    @Override
+    public String setex(String key, Date exp, String value) {
+        var item = mem.put(key, DeletionItem.builder()
+                .userId(key)
+                .exp(exp)
+                .build());
+        return item.getUserId().toString();
+    }
+
+    @Override
+    public String delete(String key) {
+        return mem.remove(key).getUserId().toString();
+    }
+
+}

--- a/src/main/java/io/quacker/domain/user/dao/UserRepository.java
+++ b/src/main/java/io/quacker/domain/user/dao/UserRepository.java
@@ -10,9 +10,11 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    public boolean existsByEmail(String email);
+    boolean existsByEmail(String email);
 
-    public Optional<User> findByEmail(String email);
+    Optional<User> findByEmail(String email);
 
-    public boolean existsByName(String name);
+    boolean existsByName(String name);
+
+    Optional<User> findByHint(String hint);
 }

--- a/src/main/java/io/quacker/domain/user/dto/DeletionItem.java
+++ b/src/main/java/io/quacker/domain/user/dto/DeletionItem.java
@@ -1,0 +1,17 @@
+package io.quacker.domain.user.dto;
+
+import lombok.Builder;
+
+import java.util.Date;
+
+@Builder
+public class DeletionItem {
+
+    private Object userId;
+    private Date exp;
+
+    public Object getUserId() { return userId; }
+
+    public Date getExp() { return exp; }
+
+}

--- a/src/main/java/io/quacker/domain/user/dto/UserCreateDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserCreateDto.java
@@ -30,5 +30,7 @@ public record UserCreateDto (
 //        @Pattern(regexp = "")
         String avatarImageUrl,
 
+        String hint,
+
         boolean isPrivate
 ) {}

--- a/src/main/java/io/quacker/domain/user/dto/UserDeletionRequest.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserDeletionRequest.java
@@ -1,0 +1,14 @@
+package io.quacker.domain.user.dto;
+
+import lombok.Builder;
+
+import java.util.Date;
+
+@Builder
+public class UserDeletionRequest {
+    private Long userId;
+    private String reason;
+    private Date exp;
+
+
+}

--- a/src/main/java/io/quacker/domain/user/dto/UserLoginDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserLoginDto.java
@@ -14,5 +14,7 @@ public record UserLoginDto(
         @Pattern(regexp = "(?=.*\\p{Ll})(?=.*\\p{Lu})(?=.*\\p{Nd})(?=.*[!@#$%^&*(),.?\":{}|<>])" +
                 "[\\p{L}\\p{Nd}!@#$%^&*(),.?\":{}|<>]{8,16}",
                 message = "비밀번호는 8~16자 사이여야 하며, 대문자, 소문자, 숫자, 특수문자를 포함해야 합니다.")
-        String password
+        String password,
+
+        boolean isAutoLogin
 ) {}

--- a/src/main/java/io/quacker/domain/user/entity/User.java
+++ b/src/main/java/io/quacker/domain/user/entity/User.java
@@ -14,12 +14,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -44,6 +45,11 @@ public class User extends BaseEntity {
     private String bio;
 
     private String avatarImageUrl;
+
+    private String hint;
+
+    @Setter
+    private Date deletedAt;
 
     private boolean isVerified;
 
@@ -105,5 +111,6 @@ public class User extends BaseEntity {
     public void changePassword(String password) {
         this.password = password;
     }
+
 }
 

--- a/src/main/java/io/quacker/domain/user/service/CustomUserDetailsService.java
+++ b/src/main/java/io/quacker/domain/user/service/CustomUserDetailsService.java
@@ -21,6 +21,9 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(()-> new CustomException("UsernameNotFoundException", 404));
 
-        return new CustomUserDetails(user.getId(), user.getEmail(), user.getPassword());
+        return new CustomUserDetails(
+                user.getId(),
+                user.getEmail(),
+                user.getPassword());
     }
 }

--- a/src/main/java/io/quacker/domain/user/service/UserDeletionService.java
+++ b/src/main/java/io/quacker/domain/user/service/UserDeletionService.java
@@ -1,0 +1,52 @@
+package io.quacker.domain.user.service;
+
+import io.quacker.common.dao.UserDeletionRepository;
+import io.quacker.domain.user.dao.UserRepository;
+import io.quacker.domain.user.dto.DeletionItem;
+import io.quacker.domain.user.entity.User;
+import io.quacker.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@EnableScheduling
+@RequiredArgsConstructor
+@Service
+public class UserDeletionService {
+
+    private final UserRepository userRepository;
+    private final UserDeletionRepository userDeletionRepository;
+
+
+    public void addRequest(Long userId, Date exp) {
+        userDeletionRepository.setex(String.valueOf(userId), exp, "");
+    }
+
+    public String abortRequest(String key) {
+        return userDeletionRepository.delete(key);
+    }
+
+    /**
+     * 배치나, 스케줄 추가하여 만료토큰 정기적으로 삭제?
+     * 현시간 부로 만료된 토큰을 모두 제거
+     * 10초마다 삭제
+     */
+    @Scheduled(fixedDelay = 10000)
+    public void deleteExpiredItem() {
+        // 저장소의 모든 키를 순회하며 만료된 요청을 삭제
+        for (Object key : userDeletionRepository.getAllKeys()) {
+            DeletionItem item = (DeletionItem)key;
+
+            if (item.getExp().before(new Date())) {
+                User user = userRepository.findById((Long)item.getUserId())
+                        .orElseThrow(()-> new CustomException("", HttpStatus.BAD_REQUEST.value()));
+                userRepository.delete(user);
+                userDeletionRepository.delete((String) item.getUserId());
+            }
+        }
+    }
+}

--- a/src/main/java/io/quacker/domain/user/service/UserService.java
+++ b/src/main/java/io/quacker/domain/user/service/UserService.java
@@ -203,9 +203,16 @@ public class UserService {
     /**
      * REQ_005	<h4>비밀번호 재설정</h4>
      * 비밀번호, 확인 비밀번호를 확인 후 저장합니다.
+     *
+     * 비밀번호 변경 세션을 만들어서 인증을 받아야함
+     *
+     *
      * @param dto 비밀번호, 확인 비밀번호를 담은 dto
      */
     public void resetPassword(UserCreateDto dto) {
+
+        //Todo : 인증 세션, 또는 인증코드리스트 유지 존재하는 요청인지 확인해한다.
+
         if (!dto.password().equals(dto.confirmPassword()))
             throw new CustomException("비밀번호가 일치하지 않음", 400);
         var user = userRepository.findByEmail(dto.email())

--- a/src/main/java/io/quacker/domain/user/service/UserService.java
+++ b/src/main/java/io/quacker/domain/user/service/UserService.java
@@ -1,16 +1,17 @@
 package io.quacker.domain.user.service;
 
 import io.quacker.common.util.JwtTokenUtil;
+import io.quacker.domain.auth.dto.JwtTokens;
+import io.quacker.domain.auth.service.JwtBlacklistService;
 import io.quacker.domain.user.dao.UserRepository;
-import io.quacker.domain.user.dto.CustomUserDetails;
-import io.quacker.domain.user.dto.UserCreateDto;
-import io.quacker.domain.user.dto.UserDto;
-import io.quacker.domain.user.dto.UserLoginDto;
-import io.quacker.domain.user.dto.UserUpdateDto;
+import io.quacker.domain.user.dto.*;
 import io.quacker.domain.user.entity.User;
 import io.quacker.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -28,6 +31,43 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenUtil jwtTokenUtil;
     private final UserRepository userRepository;
+    private final JwtBlacklistService jwtBlacklistService;
+    private final UserDeletionService userDeletionService;
+    private final Long PENDDING_TIME = 60000L;
+    /**
+     * 토큰 재발급 요청
+     * @param token
+     */
+    public JwtTokens refresh(String token) {
+
+        // 리프레시 토큰 유료검사
+        if (jwtTokenUtil.isTokenExpired(token)){
+            throw new CustomException("유효하지 않은 토큰", HttpStatus.BAD_REQUEST.value());
+        }
+
+        // 블랙리스트 유효 검사
+        if (!jwtBlacklistService.validateToken(token)) {
+            throw new CustomException("유효하지 않은 리프레시 토큰", HttpStatus.BAD_REQUEST.value());
+        }
+
+        // 리프레시토큰 블랙리스트 등록
+        jwtBlacklistService.registerToken(token);
+
+        // 토큰 subject 추출
+        User user = userRepository.findById(jwtTokenUtil.extractUserId(token))
+                .orElseThrow(() -> new CustomException("유저를 찾을 수 없음", HttpStatus.NOT_FOUND.value()));
+
+        // 토큰 재발급
+        String accessToken = jwtTokenUtil.generateAccessToken(user.getId(), user.getEmail(), user.getName());
+        String refreshToken = jwtTokenUtil.generateRefreshToken(user.getId());
+
+        // 토큰 Dto 반환
+        return JwtTokens.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
 
     /**
      * REQ_002	회원가입
@@ -43,73 +83,127 @@ public class UserService {
 
         /*
          *  이메일 유효 검사 추가 할 것
+         *  인증 세션 확인
          */
 
+        // 암호와 암호확인문 일치 확인
         if (!rawPw.equals(rawConfirmPw)) {
             throw new CustomException("비밀번호가 일치하지 않음", 400);
         }
+
+        // 이메일 중복 검사
         if (userRepository.existsByEmail(email)) {
             throw new CustomException("사용할 수 없는 이메일", 409);
         }
 
+        // 엔티티 생성
         User user = User.fromCreateDtoWithHashedPassword(dto, passwordEncoder.encode(rawPw));
-
-        User result = userRepository.save(user);
-        return UserDto.from(result);
+        return UserDto.from(userRepository.save(user));
     }
 
+
     /**
-     * REQ_001	로그인
+     * REQ_001	<h4>로그인</h4>
      * 로그인 성공시 정보를 반환.
-     * @param dto, UserLoginDto
-     * @return String, JWT토큰
+     * @param dto 로그인 정보 dto
+     * @return JWT토큰 dto
      */
-    public String login(UserLoginDto dto) {
+    public JwtTokens login(UserLoginDto dto) {
+
+        // 쿠키를 삭제하고 재로그인을 막을 방법이 있나?
+        // stateful 밖에 없다.
 
         String email = dto.email();
         String rawPw = dto.password();
 
+        // user 엔티티 조회
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new CustomException("유저를 찾을 수 없음", 404));
+                .orElseThrow(() -> new CustomException("유저를 찾을 수 없음", HttpStatus.NOT_FOUND.value()));
 
         String hashedPw = user.getPassword();
 
+        // 비밀번호 일치 확인
         if (!passwordEncoder.matches(rawPw, hashedPw)) {
             throw new CustomException("비밀번호가 일치하지 않음", 400);
         }
 
-        return jwtTokenUtil.generateToken(user.getId(), user.getEmail(), user.getName());
+        // 토큰생성
+        String accessToken = jwtTokenUtil.generateAccessToken(user.getId(), email, "");
+        // if (dto.isAutoLogin() ? "30일" : "1~2시간")
+        String refreshToken = jwtTokenUtil.generateRefreshToken(user.getId());
+
+        // 토큰 Dto 반환
+        return JwtTokens.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
+
+
+    /**
+     * REQ_
+     * <h4>로그아웃</h4>
+     * 소지 토큰 만료시 로그아웃으로 간주됩니다.
+     * @param accessTokenId
+     * @param refreshTokenId
+     */
+    public void logout(String accessTokenId, String refreshTokenId) {
+
+        // 익명 사용자 예외처리
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth instanceof AnonymousAuthenticationToken) {
+            throw new CustomException("인증되지 않음", 403);
+        }
+
+        // 토큰 블랙리스트 등록
+        jwtBlacklistService.registerToken(accessTokenId);
+        jwtBlacklistService.registerToken(refreshTokenId);
+    }
+
 
     /**
      * REQ_003	회원 탈퇴 요청
+     * @return 탈퇴요청시간, 탈퇴예정시간
      */
-    public LocalDateTime requestWithdraw() {
-        var user = getCurrentUser();
-        user.freeze();
-        if (user.isLocked())
-            throw new CustomException("이미 탈퇴 요청함", 400);
-        /*
-            일정기간 유예 후 삭제할 방법 생략
-            별도의 테이블 필요할 듯
-         */
+    public Map requestDeletion() {
 
-        return LocalDateTime.now();
+        User user = getCurrentUser();
+
+        if (user.isLocked()) {
+            throw new CustomException("이미 탈퇴 요청함", HttpStatus.BAD_REQUEST.value());
+        }
+        // User 조회
+
+        // User 정지
+        user.freeze();
+
+        Date exp = new Date(System.currentTimeMillis() + PENDDING_TIME);
+        Date current = new Date();
+
+        // User 삭제 대기
+        userDeletionService.addRequest(user.getId(), exp);
+
+        return Map.of("requestAt", current, "deleteAt", exp);
     }
 
     /**
-     * REQ_004	회원 복구
+     * REQ_004	<h4>회원 복구</h4>
      */
-    public void restoreUser() {
+    public void abortUserDeletion() {
         /*
             테이블에서 삭제, 삭제될때 요청이 들오올수도
-            동시성 문제? 성공 여부판단 필요
             throw new CustomException("존재하지 않는 유저", 403);
          */
+
+        User user = getCurrentUser();
+        user.unfreeze();
+        userDeletionService.abortRequest(String.valueOf(user.getId()));
     }
 
     /**
-     * REQ_005	비밀번호 재설정
+     * REQ_005	<h4>비밀번호 재설정</h4>
+     * 비밀번호, 확인 비밀번호를 확인 후 저장합니다.
+     * @param dto 비밀번호, 확인 비밀번호를 담은 dto
      */
     public void resetPassword(UserCreateDto dto) {
         if (!dto.password().equals(dto.confirmPassword()))
@@ -122,11 +216,20 @@ public class UserService {
     }
 
     /**
-     * REQ_006	아이디 찾기
-     * 다른 정보로 계정 찾아 이메일 찾기, 마스킹된 이메일 얻기
+     * REQ_006	아이디 찾기 <br/>
+     * 다른 정보로 계정 찾아 이메일 찾기, 마스킹된 이메일 얻기, 우선 힌트로 제공
+     * @param hint 사용자가 입력한 힌트
+     * @return 마스킹된 이메일
      */
-    public String getEmailHint() {
-        return "";
+    public String getEmailByHint(String hint) {
+        User user = userRepository.findByHint(hint)
+                .orElseThrow(()-> new CustomException("유저를 찾을 수 없음", 404));
+
+        String email = user.getEmail();
+        String[] part = email.split("@");
+        StringBuilder sb = new StringBuilder();
+        sb.append(part[0].substring(0, 4)).append("****@").append(part[1]);
+        return sb.toString();
     }
 
     /**
@@ -213,6 +316,11 @@ public class UserService {
         user.updateVisibility(!user.isPrivate());
     }
 
+    /**
+     *
+     * @param email
+     * @return
+     */
     public boolean verifyEmail(String email) {
         // 이메일 보내기
         // 언제 이메일을 보냈는가를 확인해야함, 횟수 제한을 위하여
@@ -233,8 +341,8 @@ public class UserService {
    public User getCurrentUser() throws CustomException{
 
        var auth = SecurityContextHolder.getContext().getAuthentication();
-       if (auth == null) {
-           throw new CustomException("인증되지 않음", 403);
+       if (auth == null || auth instanceof AnonymousAuthenticationToken) {
+           throw new CustomException("인증되지 않음", HttpStatus.BAD_REQUEST.value());
        }
 
        if (!(auth.getPrincipal() instanceof CustomUserDetails)) {

--- a/src/main/java/io/quacker/global/config/RedisConfig.java
+++ b/src/main/java/io/quacker/global/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package io.quacker.global.config;
+
+import io.quacker.common.dao.JwtRepository;
+import io.quacker.common.dao.UserDeletionRepository;
+import io.quacker.domain.auth.dao.MemoryJwtRepository;
+import io.quacker.domain.user.dao.MemoryUserDeletionRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {
+
+    // Redis 추가시에 수정
+    @Bean
+    public JwtRepository jwtRepository() {
+        return new MemoryJwtRepository();
+    }
+
+    @Bean
+    public UserDeletionRepository userDeletionRepository() {
+        return new MemoryUserDeletionRepository();
+    }
+}

--- a/src/main/java/io/quacker/global/config/SecurityConfig.java
+++ b/src/main/java/io/quacker/global/config/SecurityConfig.java
@@ -1,9 +1,7 @@
 package io.quacker.global.config;
 
-import io.quacker.common.util.JwtTokenUtil;
-import io.quacker.domain.user.service.CustomUserDetailsService;
-import io.quacker.global.security.JwtTokenAuthenticationFilter;
-import io.quacker.global.security.JwtTokenAuthenticationProvider;
+import io.quacker.global.security.JwtAuthenticationFilter;
+import io.quacker.global.security.JwtAuthenticationProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,7 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtTokenAuthenticationFilter jwtTokenAuthenticationFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     // BCrypt 인코더 추가
     @Bean
@@ -31,18 +29,20 @@ public class SecurityConfig {
 
     // 시큐리티 체인 설정
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, JwtTokenAuthenticationProvider jwtTokenAuthenticationProvider) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationProvider jwtTokenAuthenticationProvider) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))  // iframe 허용하기 위하여
                 .authorizeHttpRequests(auth -> auth
-                                .requestMatchers("/api/v1/auth/login", "/api/v1/auth/join").permitAll()
                                 .requestMatchers("/h2-console/**").permitAll() // H2 Console 접근 허용                                .anyRequest().authenticated()
-                                .anyRequest().permitAll()
+                                .requestMatchers("/api/v1/auth/login", "/api/v1/auth/join", "/api/v1/auth/refresh").permitAll()
+                                .requestMatchers("/api/v1/auth/logout").authenticated()
+                                .anyRequest().authenticated()
+//                                .anyRequest().permitAll()
                 )
                 .authenticationProvider(jwtTokenAuthenticationProvider)
-                .addFilterBefore(jwtTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }

--- a/src/main/java/io/quacker/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/io/quacker/global/security/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package io.quacker.global.security;
 
 import io.quacker.common.util.JwtTokenUtil;
+import io.quacker.domain.auth.service.JwtBlacklistService;
 import io.quacker.domain.user.dto.CustomUserDetails;
 import io.quacker.domain.user.service.CustomUserDetailsService;
 import jakarta.servlet.FilterChain;
@@ -8,6 +9,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -15,13 +18,21 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Set;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
-public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final CustomUserDetailsService customUserDetailsService;
+    private final JwtBlacklistService jwtBlacklistService;
     private final JwtTokenUtil jwtTokenUtil;
+    private static final Set<String> WHITELIST = Set.of(
+            "/api/v1/auth/login",
+            "/api/v1/auth/join",
+            "/api/v1/auth/refresh"
+    );
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -29,38 +40,58 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain
     ) throws ServletException, IOException {
 
+        // 허용된 URI는 인증시도 하지않음
+        String uri = request.getRequestURI();
+        if(WHITELIST.stream().anyMatch(uri::startsWith)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 인증 헤더 추출
         String authorizationHeader = request.getHeader("Authorization");
 
+        // 인증 헤더 값 검사
         if ( authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            log.info("헤더 없음");
             filterChain.doFilter(request, response);
             return;
         }
 
         // 헤더 파싱
         String token = authorizationHeader.substring(7);
-//        Long userId = jwtTokenUtil.extractUserId(token);
+
+        // 엑세스 토큰 만효 확인
+        if (jwtTokenUtil.isTokenExpired(token)) {
+            log.info("토큰 만료");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 사용자 email 추출
         String email = jwtTokenUtil.extractEmail(token);
 
-        // 이메일이 존재하지않고 현재 SecurityContext에 인증 정보가 없는 경우 새로 토큰 발급
+        // 새 토큰 발급, when 이메일이 존재하지않고 현재 SecurityContext에 인증 정보가 없는 경우
         if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(email);
-
+            log.debug(String.format("User loaded name of [%s]", userDetails.getUsername()));
             // 유효한 토근인가.
-            if (jwtTokenUtil.validateToken(token, userDetails.getUserId())) {
+            if (jwtTokenUtil.validateAccessToken(token, userDetails.getUserId()) &&
+                    jwtBlacklistService.validateToken(token)) {
                 UsernamePasswordAuthenticationToken authToken =
-                        new UsernamePasswordAuthenticationToken(userDetails,
+                        //Todo : jwt 커스텀 토큰 사용? -> AuthenticationManager 위임 필요
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
                                 null, // jwt, 생략
                                 userDetails.getAuthorities());
 
 
                 // 현재 요청 정보를 인증 토큰에 설정
                 authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
                 // SecurityContext에 인증 정보 설정
                 SecurityContextHolder.getContext().setAuthentication(authToken);
             }
         }
-
-        // done
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/io/quacker/global/security/JwtAuthenticationProvider.java
+++ b/src/main/java/io/quacker/global/security/JwtAuthenticationProvider.java
@@ -1,7 +1,10 @@
 package io.quacker.global.security;
 
+import io.quacker.common.util.JwtTokenUtil;
+import io.quacker.domain.user.dto.CustomUserDetails;
 import io.quacker.domain.user.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -11,12 +14,14 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
-public class JwtTokenAuthenticationProvider implements AuthenticationProvider {
+public class JwtAuthenticationProvider implements AuthenticationProvider {
 
     private final PasswordEncoder passwordEncoder;
     private final CustomUserDetailsService customUserDetailsService;
+    private final JwtTokenUtil jwtTokenUtil;
 
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
@@ -27,10 +32,7 @@ public class JwtTokenAuthenticationProvider implements AuthenticationProvider {
             throw new BadCredentialsException("Invalid credentials");
         }
 
-        return new UsernamePasswordAuthenticationToken(
-                userDetails,
-                rawPw,
-                userDetails.getAuthorities());
+        return new JwtAuthenticationToken(userDetails.getAuthorities(), userDetails);
     }
 
     @Override

--- a/src/main/java/io/quacker/global/security/JwtAuthenticationToken.java
+++ b/src/main/java/io/quacker/global/security/JwtAuthenticationToken.java
@@ -1,0 +1,28 @@
+package io.quacker.global.security;
+
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final UserDetails principal;
+
+    public JwtAuthenticationToken(Collection<? extends GrantedAuthority> authorities, UserDetails principal) {
+        super(authorities);
+        this.principal = principal;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+}


### PR DESCRIPTION
### 📄 작업 내용

- 최신 버전 인증 필터
- 문제 있으면 revert 하겠습니다.
- 인증 후에 사용되는 JwtAuthenticationToken 객체가 추가되었습니다.
- 실제 인증은 여전히 UsernamePasswordAuthenticationFilter가 수행합니다.

### 🌠 스크린샷

-  

### 📌 이슈 링크

- https://quacker25.atlassian.net/browse/QUAC-7?atlOrigin=eyJpIjoiYjI5MDA1ZGU3Nzk4NDMxZTkzMzgwODRmNDYzMjg3ZGEiLCJwIjoiaiJ9


### 📚 앞으로의 과제

- 다음에 작업할 과제를 남겨주세요