### PR TITLE
feat/QUAC-7-Users-기능-구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,11 @@ dependencies {
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-validation
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.4.3'
 
+    dependencies {
+        implementation 'org.springframework.boot:spring-boot-starter-mail'
+    }
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/io/quacker/common/dao/EmailCodeRepository.java
+++ b/src/main/java/io/quacker/common/dao/EmailCodeRepository.java
@@ -1,0 +1,8 @@
+package io.quacker.common.dao;
+
+import org.springframework.scheduling.annotation.Scheduled;
+
+public interface EmailCodeRepository extends DefaultCacheRepository {
+
+    void deleteExpiredItem();
+}

--- a/src/main/java/io/quacker/common/dao/JwtRepository.java
+++ b/src/main/java/io/quacker/common/dao/JwtRepository.java
@@ -1,4 +1,6 @@
 package io.quacker.common.dao;
 
 public interface JwtRepository extends DefaultCacheRepository {
+
+    void deleteExpiredItem();
 }

--- a/src/main/java/io/quacker/common/dao/UserDeletionRepository.java
+++ b/src/main/java/io/quacker/common/dao/UserDeletionRepository.java
@@ -1,4 +1,8 @@
 package io.quacker.common.dao;
 
+import java.util.Date;
+import java.util.List;
+
 public interface UserDeletionRepository extends DefaultCacheRepository{
+    List<String> getAllExpiredKeys(Date now);
 }

--- a/src/main/java/io/quacker/domain/auth/dao/MemoryJwtRepository.java
+++ b/src/main/java/io/quacker/domain/auth/dao/MemoryJwtRepository.java
@@ -3,12 +3,13 @@ package io.quacker.domain.auth.dao;
 import io.quacker.common.dao.JwtRepository;
 import io.quacker.domain.auth.dto.JwtItem;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Repository;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.*;
 
 @Slf4j
-@Repository
+@EnableScheduling
 public class MemoryJwtRepository implements JwtRepository {
 
     //TODO 재발급 limit을 위한 카운트?
@@ -44,9 +45,9 @@ public class MemoryJwtRepository implements JwtRepository {
         return mem.remove(key).getTokenId().toString();
     }
 
+    @Override
+    @Scheduled(fixedDelay = 10000)
     public void deleteExpiredItem() {
-//        log.info("Current cnt : " + mem.size());
-//        mem.entrySet().removeIf(entry->entry.getValue().isBanned());
         Date now = new Date();
         mem.entrySet().removeIf(entry-> {
             log.info("["+ entry.getKey() + "]" + "   만료시간: "+  entry.getValue().getExp().toString());

--- a/src/main/java/io/quacker/domain/auth/dao/MemoryJwtRepository.java
+++ b/src/main/java/io/quacker/domain/auth/dao/MemoryJwtRepository.java
@@ -32,11 +32,12 @@ public class MemoryJwtRepository implements JwtRepository {
 
     @Override
     public String setex(String key, Date exp, String value) {
-        var item = mem.put(key, JwtItem.builder()
+
+        var item = JwtItem.builder()
                 .exp(exp)
                 .tokenId(value)
-                .build());
-
+                .build();
+        mem.put(key, item);
         return item.getTokenId().toString();
     }
 
@@ -45,11 +46,11 @@ public class MemoryJwtRepository implements JwtRepository {
         return mem.remove(key).getTokenId().toString();
     }
 
-    @Override
+
     @Scheduled(fixedDelay = 10000)
     public void deleteExpiredItem() {
         Date now = new Date();
-        mem.entrySet().removeIf(entry-> {
+        mem.entrySet().removeIf((var entry) -> {
             log.info("["+ entry.getKey() + "]" + "   만료시간: "+  entry.getValue().getExp().toString());
             return entry.getValue().getExp().before(now);
         });

--- a/src/main/java/io/quacker/domain/auth/dto/JwtTokens.java
+++ b/src/main/java/io/quacker/domain/auth/dto/JwtTokens.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record JwtTokens(
+        Long userId,
         String accessToken,
         String refreshToken
 ){}

--- a/src/main/java/io/quacker/domain/auth/service/JwtBlacklistService.java
+++ b/src/main/java/io/quacker/domain/auth/service/JwtBlacklistService.java
@@ -36,11 +36,8 @@ public class JwtBlacklistService {
      */
     public boolean validateToken(String token) {
         String key = jwtTokenUtil.extractId(token);
-        if (jwtRepository.exisits(key)){
-            return false;
-        }
-
-        return true;
+        // 만료되지않았고, 블랙리스트에 없어야한다.
+        return !jwtTokenUtil.isTokenExpired(token) && !jwtRepository.exisits(key);
     }
 
     /**

--- a/src/main/java/io/quacker/domain/user/controller/UserAuthController.java
+++ b/src/main/java/io/quacker/domain/user/controller/UserAuthController.java
@@ -1,8 +1,7 @@
 package io.quacker.domain.user.controller;
 
 import io.quacker.domain.auth.dto.JwtTokens;
-import io.quacker.domain.user.dto.UserCreateDto;
-import io.quacker.domain.user.dto.UserLoginDto;
+import io.quacker.domain.user.dto.*;
 import io.quacker.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +12,8 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -81,7 +82,8 @@ public class UserAuthController {
     @PostMapping("/refresh")
     public ResponseEntity<?> refresh(@CookieValue(value = "refreshToken") String refreshToken) {
         if (refreshToken == null || refreshToken.isBlank()) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("result", false));
         }
         JwtTokens tokens = userService.refresh(refreshToken);
         ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", tokens.accessToken())
@@ -98,7 +100,7 @@ public class UserAuthController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-                .build();
+                .body(Map.of("result", true));
     }
 
     /**
@@ -129,5 +131,45 @@ public class UserAuthController {
                 .header(HttpHeaders.SET_COOKIE, access.toString())
                 .header(HttpHeaders.SET_COOKIE, refresh.toString())
                 .body("로그아웃성공");
+    }
+
+    //힌트로 이메일 찾기
+    @GetMapping("/hint")
+    public ResponseEntity<?> getEmailhint(@RequestBody UserHintDto userHintDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(userService.getEmailByHint(userHintDto.hint()));
+    }
+
+    // 이메일 중복 확인?
+    @PostMapping("/duplicate-email")
+    public ResponseEntity<?> duplicateEmail(@RequestBody UserEmailDto userEmailDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(userService.checkDuplicateEmail(userEmailDto.email()));
+    }
+
+    // 사용자 이름 중복 확인
+    @GetMapping("/username/{username}")
+    public ResponseEntity<?> duplicateUsername(@RequestBody UserDto userDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(userService.checkDuplicateUsername(userDto.name()));
+    }
+
+    // 이메일 인증 발송
+    @PostMapping("/send-code")
+    public ResponseEntity<?> createEmailSession(@RequestBody UserEmailDto userEmailDto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(userService.sendCode(userEmailDto.email()));
+    }
+
+    // 현재 캐시에 저장된 코드와 비교
+    @PutMapping("/verify-email")
+    public ResponseEntity<?> verifyEmail(@RequestBody UserEmailCodeDto userEmailCodeDto) {
+        String email = userEmailCodeDto.email();
+        String code = userEmailCodeDto.code();
+        return ResponseEntity.status(HttpStatus.OK).body(userService.verifyEmailCode(email, code));
+    }
+
+
+    // 사용자 비밀번호 변경(인증 세션 필요)
+    @PutMapping("/reset-password")
+    public ResponseEntity<?> resetPassword(@RequestBody UserResetPasswordDto userResetPasswordDto) {
+        userService.resetPassword(userResetPasswordDto);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("result", true));
     }
 }

--- a/src/main/java/io/quacker/domain/user/controller/UserAuthController.java
+++ b/src/main/java/io/quacker/domain/user/controller/UserAuthController.java
@@ -51,13 +51,12 @@ public class UserAuthController {
                 .maxAge(14 * 24 * 60 * 60)
 //                .sameSite("Strict")
                 .build();
-
-
+        
         // ResponseEntity에 헤더와 응답 본문 설정
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-                .build();
+                .body(userService.getUserById(tokens.userId()));
     }
 
     /**

--- a/src/main/java/io/quacker/domain/user/controller/UserController.java
+++ b/src/main/java/io/quacker/domain/user/controller/UserController.java
@@ -1,12 +1,10 @@
 package io.quacker.domain.user.controller;
 
-import io.quacker.domain.user.dto.CustomUserDetails;
-import io.quacker.domain.user.dto.UserCreateDto;
+import io.quacker.domain.user.dto.UserUpdateDto;
 import io.quacker.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -21,67 +19,41 @@ public class UserController {
     @PatchMapping("/visibility")
     public ResponseEntity<?> toggleVisibility(){
         userService.toggleVisibility();
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("result", true));
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(Map.of("result", true));
     }
 
     //삭제 "요청"
     @PostMapping("/delete")
-    public ResponseEntity<?> requestDelete(@PathVariable("userId") Long userId) {
-        //Todo : RESTful 한 설계이어야하나? 리소스 식별자가 필요한가.
-        return ResponseEntity.status(HttpStatus.OK).body(userService.requestDeletion());
+    public ResponseEntity<?> requestDelete() {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userService.requestDeletion());
     }
 
     //삭제 취소
     @PostMapping("/abort")
-    public ResponseEntity<?> abort(@PathVariable("userId") Long userId) {
-        //Todo : RESTful 한 설계이어야하나?
+    public ResponseEntity<?> abort() {
         userService.abortUserDeletion();
-        return ResponseEntity.status(HttpStatus.OK).body("done");
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(Map.of("result", true));
     }
 
-    //힌트로 이메일 찾기
-    @GetMapping("/hint")
-    public ResponseEntity<?> getEmailhint(@RequestBody String hint) {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.getEmailByHint(hint));
+    // 프로필
+    @GetMapping("/edit")
+    public ResponseEntity<?> getProfile() {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userService.getUserProfile());
     }
 
-    // 이메일 중복 확인?
-    @GetMapping("/email/{email}")
-    public ResponseEntity<?> duplicateEmail(@PathVariable("email") String email) {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.checkDuplicateEmail(email));
-    }
-
-    // 사용자 이름 중복 확인
-    @GetMapping("/username/{username}")
-    public ResponseEntity<?> duplicateUsername(@PathVariable("username") String username) {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.checkDuplicateUsername(username));
-    }
-
-    // 인증 세션 생성
-    @PostMapping("/session")
-    public ResponseEntity<?> createSession(@RequestBody String email) {
-        // 1. 이메일 중복확인
-        // 2. 이메일기반으로 세션 생성(유효 15분)
-        // 3. 이메일로 인증하고 인증성공시 유효한 세선 전환
-        //ToDo 생성된 세션의 식별자(세션id)와 생성시간 만료시간
-        return ResponseEntity.status(HttpStatus.CREATED).body("created");
-    }
-
-    // 사용자 비밀번호 변경(인증 세션 필요)
-    @PutMapping("/reset-password")
-    public ResponseEntity<?> resetPassword(@RequestBody UserCreateDto userCreateDto) {
-        // 1. 세션 인증 확인
-        // 2. 세션종료, 세션 삭제
-        userService.resetPassword(userCreateDto);
-        //TODO : 성공 response dto?
-        return ResponseEntity.status(HttpStatus.OK).body("done");
-    }
-
-    @PutMapping("/session/verify")
-    public ResponseEntity<?> verifyEmail(@RequestBody UserCreateDto userCreateDto) {
-        // 1. 생성시간이 만료된 세션을 삭제
-        // 2. 인증 성공시 세션 상태를 verify로 변경
-        // TODO : join api에 verify 하고 성공시에 user.verified =true로 변경하여 save할 것
-        return null;
+    // 프로필 수정
+    @PutMapping("/edit")
+    public ResponseEntity<?> editProfile(@RequestBody UserUpdateDto userUpdateDto) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userService.updateUserProfile(userUpdateDto));
     }
 }

--- a/src/main/java/io/quacker/domain/user/controller/UserController.java
+++ b/src/main/java/io/quacker/domain/user/controller/UserController.java
@@ -41,19 +41,22 @@ public class UserController {
                 .body(Map.of("result", true));
     }
 
-    // 프로필
-    @GetMapping("/")
-    public ResponseEntity<?> getProfile() {
+    // 프로필 조회
+    @GetMapping("/{userId}")
+    public ResponseEntity<?> getProfile(@PathVariable("userId") Long userId) {
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(userService.getUserProfile());
+                .body(userService.getUserById(userId));
     }
 
     // 프로필 수정
-    @PutMapping("/edit")
-    public ResponseEntity<?> editProfile(@RequestBody UserUpdateDto userUpdateDto) {
+    @PutMapping("/{userId}/edit")
+    public ResponseEntity<?> editProfile(
+            @PathVariable("userId") Long userId,
+            @RequestBody UserUpdateDto userUpdateDto
+    ) {
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(userService.updateUserProfile(userUpdateDto));
+                .body(userService.updateMyProfile(userId, userUpdateDto));
     }
 }

--- a/src/main/java/io/quacker/domain/user/controller/UserController.java
+++ b/src/main/java/io/quacker/domain/user/controller/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
     }
 
     // 프로필
-    @GetMapping("/edit")
+    @GetMapping("/")
     public ResponseEntity<?> getProfile() {
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/io/quacker/domain/user/dao/MemoryEmailCodeRepository.java
+++ b/src/main/java/io/quacker/domain/user/dao/MemoryEmailCodeRepository.java
@@ -1,0 +1,55 @@
+package io.quacker.domain.user.dao;
+
+import io.quacker.common.dao.EmailCodeRepository;
+import io.quacker.domain.user.dto.EmailCodeItem;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.*;
+
+@Slf4j
+@EnableScheduling
+public class MemoryEmailCodeRepository implements EmailCodeRepository {
+
+    private final Map<String, EmailCodeItem> mem = new HashMap<>();
+
+    @Override
+    public boolean exisits(String key) {
+        return mem.get(key) != null;
+    }
+
+    @Override
+    public Optional<String> get(String key) {
+        return Optional.ofNullable(mem.get(key).getCode());
+    }
+
+    @Override
+    public List<Object> getAllKeys() {
+        return Arrays.asList(mem.keySet().toArray());
+    }
+
+    @Override
+    public String setex(String key, Date exp, String value) {
+        var save = EmailCodeItem.builder()
+                .code(value)
+                .exp(exp)
+                .build();
+        mem.put(key, save);
+        return save.getCode();
+    }
+
+    @Override
+    public String delete(String key) {
+        return mem.remove(key).getCode();
+    }
+
+    @Scheduled(fixedDelay = 10000)
+    public void deleteExpiredItem() {
+        Date now = new Date();
+        mem.entrySet().removeIf(entry-> {
+            log.info("["+ entry.getKey() + "]" + "   만료시간: "+  entry.getValue().getExp().toString());
+            return entry.getValue().getExp().before(now);
+        });
+    }
+}

--- a/src/main/java/io/quacker/domain/user/dao/MemoryUserDeletionRepository.java
+++ b/src/main/java/io/quacker/domain/user/dao/MemoryUserDeletionRepository.java
@@ -2,9 +2,14 @@ package io.quacker.domain.user.dao;
 
 import io.quacker.common.dao.UserDeletionRepository;
 import io.quacker.domain.user.dto.DeletionItem;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.*;
 
+@Slf4j
+@EnableScheduling
 public class MemoryUserDeletionRepository implements UserDeletionRepository {
 
     private final Map<String, DeletionItem> mem = new HashMap<>();
@@ -36,4 +41,13 @@ public class MemoryUserDeletionRepository implements UserDeletionRepository {
         return mem.remove(key).getUserId().toString();
     }
 
+    @Override
+    @Scheduled(fixedDelay = 10000)
+    public void deleteExpiredItem() {
+        Date now = new Date();
+        mem.entrySet().removeIf(entry-> {
+            log.info("["+ entry.getKey() + "]" + "   만료시간: "+  entry.getValue().getExp().toString());
+            return entry.getValue().getExp().before(now);
+        });
+    }
 }

--- a/src/main/java/io/quacker/domain/user/dao/MemoryUserDeletionRepository.java
+++ b/src/main/java/io/quacker/domain/user/dao/MemoryUserDeletionRepository.java
@@ -2,14 +2,12 @@ package io.quacker.domain.user.dao;
 
 import io.quacker.common.dao.UserDeletionRepository;
 import io.quacker.domain.user.dto.DeletionItem;
+import io.quacker.domain.user.entity.User;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.*;
 
 @Slf4j
-@EnableScheduling
 public class MemoryUserDeletionRepository implements UserDeletionRepository {
 
     private final Map<String, DeletionItem> mem = new HashMap<>();
@@ -29,25 +27,31 @@ public class MemoryUserDeletionRepository implements UserDeletionRepository {
 
     @Override
     public String setex(String key, Date exp, String value) {
-        var item = mem.put(key, DeletionItem.builder()
+        var item = DeletionItem.builder()
                 .userId(key)
                 .exp(exp)
-                .build());
+                .build();
+        mem.put(key, item);
         return item.getUserId().toString();
     }
 
     @Override
     public String delete(String key) {
-        return mem.remove(key).getUserId().toString();
+        var item = mem.remove(key);
+        if (item == null)
+            return null;
+        return item.getUserId().toString();
     }
 
     @Override
-    @Scheduled(fixedDelay = 10000)
-    public void deleteExpiredItem() {
-        Date now = new Date();
-        mem.entrySet().removeIf(entry-> {
-            log.info("["+ entry.getKey() + "]" + "   만료시간: "+  entry.getValue().getExp().toString());
-            return entry.getValue().getExp().before(now);
-        });
+    public List<String> getAllExpiredKeys(Date now) {
+        List<String> result = new ArrayList<>();
+        for (String key : mem.keySet()) {
+            if (mem.get(key).getExp().before(now)){
+                result.add(key);
+            }
+        }
+        return result;
     }
+
 }

--- a/src/main/java/io/quacker/domain/user/dto/CustomUserDetails.java
+++ b/src/main/java/io/quacker/domain/user/dto/CustomUserDetails.java
@@ -15,10 +15,13 @@ public class CustomUserDetails implements UserDetails {
     private final Long userId;
     private final String email;
     private final String password;
+    private List<GrantedAuthority> authorities;
+
+
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
+        return authorities;
     }
 
     @Override

--- a/src/main/java/io/quacker/domain/user/dto/EmailCodeItem.java
+++ b/src/main/java/io/quacker/domain/user/dto/EmailCodeItem.java
@@ -1,0 +1,13 @@
+package io.quacker.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+@Builder
+public class EmailCodeItem {
+    private String code;
+    private Date exp;
+}

--- a/src/main/java/io/quacker/domain/user/dto/UserEmailCodeDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserEmailCodeDto.java
@@ -1,0 +1,14 @@
+package io.quacker.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+@Builder
+public record UserEmailCodeDto(
+        @NotBlank
+        @Email(regexp = "^(?=.*\\.).*$", message = "이메일 형식")
+        String email,
+        String code
+) {}

--- a/src/main/java/io/quacker/domain/user/dto/UserEmailDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserEmailDto.java
@@ -1,0 +1,13 @@
+package io.quacker.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+@Builder
+public record UserEmailDto(
+        @NotBlank
+        @Email(regexp = "^(?=.*\\.).*$", message = "이메일 형식")
+        String email
+) {}

--- a/src/main/java/io/quacker/domain/user/dto/UserHintDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserHintDto.java
@@ -1,0 +1,11 @@
+package io.quacker.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+@Builder
+public record UserHintDto(
+        String hint
+) {}

--- a/src/main/java/io/quacker/domain/user/dto/UserResetPasswordDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserResetPasswordDto.java
@@ -1,0 +1,25 @@
+package io.quacker.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+@Builder
+public record UserResetPasswordDto(
+        @NotBlank
+        @Email(regexp = "^(?=.*\\.).*$", message = "이메일 형식")
+        String email,
+
+        @Pattern(regexp = "(?=.*\\p{Ll})(?=.*\\p{Lu})(?=.*\\p{Nd})(?=.*[!@#$%^&*(),.?\":{}|<>])" +
+                "[\\p{L}\\p{Nd}!@#$%^&*(),.?\":{}|<>]{8,16}",
+                message = "비밀번호는 8~16자 사이여야 하며, 대문자, 소문자, 숫자, 특수문자를 포함해야 합니다.")
+        String newPassword,
+
+        @Pattern(regexp = "(?=.*\\p{Ll})(?=.*\\p{Lu})(?=.*\\p{Nd})(?=.*[!@#$%^&*(),.?\":{}|<>])" +
+                "[\\p{L}\\p{Nd}!@#$%^&*(),.?\":{}|<>]{8,16}",
+                message = "비밀번호는 8~16자 사이여야 하며, 대문자, 소문자, 숫자, 특수문자를 포함해야 합니다.")
+        String newConfirmPassword,
+
+        String code
+) {}

--- a/src/main/java/io/quacker/domain/user/dto/UserUpdateDto.java
+++ b/src/main/java/io/quacker/domain/user/dto/UserUpdateDto.java
@@ -21,13 +21,9 @@ public record UserUpdateDto(
 
         String avatarImageUrl,
 
-        boolean isVerified,
-
         boolean isLocked, // 정지
 
-        boolean isPrivate, // 계정 공개
-
-        List<Post> posts
+        boolean isPrivate// 계정 공개
 ){
 
 }

--- a/src/main/java/io/quacker/domain/user/entity/User.java
+++ b/src/main/java/io/quacker/domain/user/entity/User.java
@@ -51,6 +51,7 @@ public class User extends BaseEntity {
     @Setter
     private Date deletedAt;
 
+    @Setter
     private boolean isVerified;
 
     private boolean isLocked;
@@ -97,9 +98,9 @@ public class User extends BaseEntity {
                 .bio(userCreateDto.bio())
                 .avatarImageUrl(userCreateDto.avatarImageUrl())
                 .isPrivate(userCreateDto.isPrivate())
+                .isVerified(false)
                 .build();
     }
-
 
     public void updateProfile(String name, String bio, String avatarImageUrl, boolean isLocked, boolean isPrivate) {
         this.name = name;

--- a/src/main/java/io/quacker/domain/user/service/CustomUserDetailsService.java
+++ b/src/main/java/io/quacker/domain/user/service/CustomUserDetailsService.java
@@ -5,10 +5,15 @@ import io.quacker.domain.user.dto.CustomUserDetails;
 import io.quacker.domain.user.entity.User;
 import io.quacker.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,9 +26,27 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(()-> new CustomException("UsernameNotFoundException", 404));
 
+        if (user.getDeletedAt() != null) {
+            throw new CustomException("Deleted User", 404);
+        }
+
+        if (user.isLocked()) {
+            throw new CustomException("Suspended user", 404);
+        }
+
+        // 권한 부여
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        if (user.isVerified()) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        } else {
+            authorities.add(new SimpleGrantedAuthority("ROLE_UNVERIFIED_USER"));
+        }
+
         return new CustomUserDetails(
                 user.getId(),
                 user.getEmail(),
-                user.getPassword());
+                user.getPassword(),
+                authorities
+        );
     }
 }

--- a/src/main/java/io/quacker/domain/user/service/EmailCodeService.java
+++ b/src/main/java/io/quacker/domain/user/service/EmailCodeService.java
@@ -1,0 +1,12 @@
+package io.quacker.domain.user.service;
+
+import java.util.Date;
+
+public interface EmailCodeService {
+
+    Date sendCode(String email);
+
+    boolean verifyCode(String email, String code);
+
+    void deleteCodeByEmail(String email);
+}

--- a/src/main/java/io/quacker/domain/user/service/EmailCodeServiceImpl.java
+++ b/src/main/java/io/quacker/domain/user/service/EmailCodeServiceImpl.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Date;

--- a/src/main/java/io/quacker/domain/user/service/EmailCodeServiceImpl.java
+++ b/src/main/java/io/quacker/domain/user/service/EmailCodeServiceImpl.java
@@ -1,0 +1,77 @@
+package io.quacker.domain.user.service;
+
+import io.quacker.common.dao.EmailCodeRepository;
+import io.quacker.global.exception.CustomException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+public class EmailCodeServiceImpl implements EmailCodeService {
+
+    private final JavaMailSender mailSender;
+    private final EmailCodeRepository emailCodeRepository;
+    private final Long CODE_EXPIRATION_TIME;
+
+    // 인증 발송 및 캐시추가
+    @Override
+    public Date sendCode (String email) {
+        UUID uuid = UUID.randomUUID();
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+            log.info(email.trim());
+            helper.setTo(email.trim());
+            helper.setSubject("Quacker 인증 코드");
+            helper.setText(uuid.toString(), false); // HTML false
+
+            helper.setFrom("no-reply@gmail.com", "Quacker"); // 발신자 이름
+
+            mailSender.send(message);
+
+        } catch (MessagingException e) {
+            throw new CustomException("발송 실패 : " + e.getMessage(), HttpStatus.BAD_REQUEST.value());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+        Date now = new Date();
+        Date exp = new Date(System.currentTimeMillis() + CODE_EXPIRATION_TIME);
+
+        //Redis에 추가
+        emailCodeRepository.setex(email, exp, uuid.toString());
+
+        return now;
+    }
+
+    @Override
+    public boolean verifyCode(String email, String code) {
+
+        // 이메일에 해당하는 검증이 있는지 확인
+        var result = emailCodeRepository.get(email)
+                .orElseThrow(()->new CustomException("만료되거나 존재하지않은 인증", HttpStatus.BAD_REQUEST.value()));
+
+        // 코드 일치 여부 반환
+        boolean verified = result.equals(code);
+
+        // 인증 성공시 인증캐시 삭제
+        if (verified) {
+            emailCodeRepository.delete(email);
+        }
+        return verified;
+    }
+
+    @Override
+    public void deleteCodeByEmail(String email) {
+        emailCodeRepository.delete(email);
+    }
+}

--- a/src/main/java/io/quacker/domain/user/service/EmailCodeServiceStub.java
+++ b/src/main/java/io/quacker/domain/user/service/EmailCodeServiceStub.java
@@ -5,22 +5,29 @@ import io.quacker.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
 
 import java.util.Date;
 import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
-public class EmailServiceStub implements EmailCodeService {
+public class EmailCodeServiceStub implements EmailCodeService {
 
     private final EmailCodeRepository emailCodeRepository;
+    private final Long CODE_EXPIRATION_TIME;
 
     @Override
-    public Date sendCode (String to) {
+    public Date sendCode (String email) {
         UUID uuid = UUID.randomUUID();
-        log.info(uuid.toString());
-        return new Date();
+        log.info(email + " CODE : "+ uuid.toString());
+
+        Date now = new Date();
+        Date exp = new Date(System.currentTimeMillis() + CODE_EXPIRATION_TIME);
+
+        //Redis에 추가
+        emailCodeRepository.setex(email, exp, uuid.toString());
+
+        return now;
     }
 
     @Override

--- a/src/main/java/io/quacker/domain/user/service/EmailServiceStub.java
+++ b/src/main/java/io/quacker/domain/user/service/EmailServiceStub.java
@@ -1,0 +1,47 @@
+package io.quacker.domain.user.service;
+
+import io.quacker.common.dao.EmailCodeRepository;
+import io.quacker.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+public class EmailServiceStub implements EmailCodeService {
+
+    private final EmailCodeRepository emailCodeRepository;
+
+    @Override
+    public Date sendCode (String to) {
+        UUID uuid = UUID.randomUUID();
+        log.info(uuid.toString());
+        return new Date();
+    }
+
+    @Override
+    public boolean verifyCode(String email, String code) {
+
+        // 이메일에 해당하는 검증이 있는지 확인
+        var result = emailCodeRepository.get(email)
+                .orElseThrow(()->new CustomException("만료되거나 존재하지않은 인증", HttpStatus.BAD_REQUEST.value()));
+
+        // 코드 일치 여부 반환
+        boolean verified = result.equals(code);
+
+        // 인증 성공시 인증캐시 삭제
+        if (verified) {
+            emailCodeRepository.delete(email);
+        }
+        return verified;
+    }
+
+    @Override
+    public void deleteCodeByEmail(String email) {
+        emailCodeRepository.delete(email);
+    }
+}

--- a/src/main/java/io/quacker/domain/user/service/UserDeletionService.java
+++ b/src/main/java/io/quacker/domain/user/service/UserDeletionService.java
@@ -2,51 +2,64 @@ package io.quacker.domain.user.service;
 
 import io.quacker.common.dao.UserDeletionRepository;
 import io.quacker.domain.user.dao.UserRepository;
-import io.quacker.domain.user.dto.DeletionItem;
-import io.quacker.domain.user.entity.User;
 import io.quacker.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
+import java.util.List;
 
-@EnableScheduling
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class UserDeletionService {
 
-    private final UserRepository userRepository;
     private final UserDeletionRepository userDeletionRepository;
-
+    private final UserRepository userRepository;
 
     public void addRequest(Long userId, Date exp) {
         userDeletionRepository.setex(String.valueOf(userId), exp, "");
     }
 
-    public String abortRequest(String key) {
-        return userDeletionRepository.delete(key);
+    public void abortRequest(String key) {
+        if (!userDeletionRepository.exisits(key))
+            throw new CustomException("취소할 삭제요청이 없습니다.", HttpStatus.BAD_REQUEST.value());
+        userDeletionRepository.delete(key);
     }
 
     /**
-     * 배치나, 스케줄 추가하여 만료토큰 정기적으로 삭제?
-     * 현시간 부로 만료된 토큰을 모두 제거
-     * 10초마다 삭제
+     * 완전 삭제가 아님
      */
     @Scheduled(fixedDelay = 10000)
+    @Transactional
     public void deleteExpiredItem() {
-        // 저장소의 모든 키를 순회하며 만료된 요청을 삭제
-        for (Object key : userDeletionRepository.getAllKeys()) {
-            DeletionItem item = (DeletionItem)key;
+        Date now = new Date();
+        List<String> keys =  userDeletionRepository.getAllExpiredKeys(now);
 
-            if (item.getExp().before(new Date())) {
-                User user = userRepository.findById((Long)item.getUserId())
-                        .orElseThrow(()-> new CustomException("", HttpStatus.BAD_REQUEST.value()));
-                userRepository.delete(user);
-                userDeletionRepository.delete((String) item.getUserId());
-            }
+        if(!keys.isEmpty())
+            log.info(String.format("%d users deleted.", keys.size()));
+
+        for (String key : keys) {
+            var id = Long.parseLong(key);
+            if (!userRepository.existsById(id))
+                continue;
+
+            var user = userRepository.findById(id).get();
+
+            // 소프트 삭제 처리
+            user.setDeletedAt(now);
+            /*
+            다른 개인정보 필드 마스킹 또는 지우기
+             */
+
+            // 요청 캐시 삭제
+            userDeletionRepository.delete(key);
+
+            //TODO 삭제 대상자의 토큰 모두 만료 필요
         }
     }
 }

--- a/src/main/java/io/quacker/domain/user/service/UserService.java
+++ b/src/main/java/io/quacker/domain/user/service/UserService.java
@@ -17,8 +17,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Map;
 
@@ -33,6 +31,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final JwtBlacklistService jwtBlacklistService;
     private final UserDeletionService userDeletionService;
+    private final EmailCodeService emailCodeService;
     private final Long PENDDING_TIME = 60000L;
     /**
      * 토큰 재발급 요청
@@ -77,14 +76,13 @@ public class UserService {
      */
     public UserDto join(UserCreateDto dto) {
 
+        /**
+         * 인증받지않은 유저
+         */
+
         String email = dto.email();
         String rawPw = dto.password();
         String rawConfirmPw = dto.confirmPassword();
-
-        /*
-         *  이메일 유효 검사 추가 할 것
-         *  인증 세션 확인
-         */
 
         // 암호와 암호확인문 일치 확인
         if (!rawPw.equals(rawConfirmPw)) {
@@ -119,6 +117,11 @@ public class UserService {
         // user 엔티티 조회
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException("유저를 찾을 수 없음", HttpStatus.NOT_FOUND.value()));
+
+        if (user.getDeletedAt() != null) {
+            // 삭제된 유저
+            throw new CustomException("유저를 찾을 수 없음", HttpStatus.NOT_FOUND.value());
+        }
 
         String hashedPw = user.getPassword();
 
@@ -173,15 +176,13 @@ public class UserService {
             throw new CustomException("이미 탈퇴 요청함", HttpStatus.BAD_REQUEST.value());
         }
         // User 조회
+        Date exp = new Date(System.currentTimeMillis() + PENDDING_TIME);
+        Date current = new Date();
+        userDeletionService.addRequest(user.getId(), exp);
+
 
         // User 정지
         user.freeze();
-
-        Date exp = new Date(System.currentTimeMillis() + PENDDING_TIME);
-        Date current = new Date();
-
-        // User 삭제 대기
-        userDeletionService.addRequest(user.getId(), exp);
 
         return Map.of("requestAt", current, "deleteAt", exp);
     }
@@ -209,16 +210,24 @@ public class UserService {
      *
      * @param dto 비밀번호, 확인 비밀번호를 담은 dto
      */
-    public void resetPassword(UserCreateDto dto) {
+    @Transactional
+    public void resetPassword(UserResetPasswordDto dto) {
 
-        //Todo : 인증 세션, 또는 인증코드리스트 유지 존재하는 요청인지 확인해한다.
+        // 인증코드 검증
+        if(!emailCodeService.verifyCode(dto.email(), dto.code())) {
+            throw new CustomException("인증코드가 유효하지않음", HttpStatus.BAD_REQUEST.value());
+        }
 
-        if (!dto.password().equals(dto.confirmPassword()))
+        // 새 비밀번호가 유효하지않음
+        if (!dto.newPassword().equals(dto.newConfirmPassword()))
             throw new CustomException("비밀번호가 일치하지 않음", 400);
+
+        // 이메일로 유저 찾기
         var user = userRepository.findByEmail(dto.email())
                 .orElseThrow(()-> new CustomException("유저를 찾을 수 없음", 404));
 
-        String hashedPw = passwordEncoder.encode(dto.password());
+        // 인코딩 후 저장
+        String hashedPw = passwordEncoder.encode(dto.newPassword());
         user.changePassword(hashedPw);
     }
 
@@ -263,18 +272,18 @@ public class UserService {
     public UserDto getUserProfile() {
         return UserDto.from(getCurrentUser());
     }
-
-    /**a
-     * REQ_011	프로필 조회
-     * 특정 사용자 조회
-     * @param userId, Long
-     * @return UserDto
-     */
-    public UserDto getUserById(Long userId) {
-        return UserDto.from(userRepository.findById(userId)
-                .orElseThrow(()-> new CustomException("유저를 찾을 수 없음", 404)));
-    }
-
+//
+//    /**a
+//     * REQ_011	프로필 조회
+//     * 특정 사용자 조회
+//     * @param userId, Long
+//     * @return UserDto
+//     */
+//    public UserDto getUserById(Long userId) {
+//        return UserDto.from(userRepository.findById(userId)
+//                .orElseThrow(()-> new CustomException("유저를 찾을 수 없음", 404)));
+//    }
+//
     /**
      * REQ_012	프로필 수정
      * 나의 프로필 수정
@@ -293,27 +302,27 @@ public class UserService {
 
         return UserDto.from(user);
     }
-
-    /**
-     * REQ_012	프로필 수정
-     * 특정 프로필 수정
-     * @param userId, Long
-     * @param dto, UserUpdateDto
-     * @return UserDto
-     */
-    public UserDto updateUserProfile(Long userId, UserUpdateDto dto) {
-        var user = userRepository.findById(userId)
-                .orElseThrow(()-> new CustomException("유저를 찾을 수 없음", 404));
-        user.updateProfile(
-                dto.name(),
-                dto.bio(),
-                dto.avatarImageUrl(),
-                dto.isLocked(),
-                dto.isPrivate()
-        );
-
-        return UserDto.from(user);
-    }
+//
+//    /**
+//     * REQ_012	프로필 수정
+//     * 특정 프로필 수정
+//     * @param userId, Long
+//     * @param dto, UserUpdateDto
+//     * @return UserDto
+//     */
+//    public UserDto updateUserProfile(Long userId, UserUpdateDto dto) {
+//        var user = userRepository.findById(userId)
+//                .orElseThrow(()-> new CustomException("유저를 찾을 수 없음", 404));
+//        user.updateProfile(
+//                dto.name(),
+//                dto.bio(),
+//                dto.avatarImageUrl(),
+//                dto.isLocked(),
+//                dto.isPrivate()
+//        );
+//
+//        return UserDto.from(user);
+//    }
 
     /**
      * REQ_013	공개여부 토글
@@ -325,21 +334,35 @@ public class UserService {
 
     /**
      *
+     * @return
+     */
+    public Map<?,?> sendCode(String email) {
+        return Map.of("sentAT", emailCodeService.sendCode(email));
+    }
+
+    /**
+     *
      * @param email
      * @return
      */
-    public boolean verifyEmail(String email) {
+    @Transactional
+    public boolean verifyEmailCode(String email, String code) {
+        User user = getCurrentUser();
+
         // 이메일 보내기
         // 언제 이메일을 보냈는가를 확인해야함, 횟수 제한을 위하여
-
-
-        LocalDateTime expiration = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
-        if (expiration.isAfter(LocalDateTime.now())) {
-
+        if (!emailCodeService.verifyCode(email, code)) {
+            throw new CustomException("코드 인증 실패", HttpStatus.BAD_REQUEST.value());
         }
-        return false;
-    }
 
+        user.setVerified(true);
+
+        /**
+         * ROLE 변경
+         */
+
+        return true;
+    }
 
     /**
      * 현재 로그인된 User 영속성 엔티티 반환.

--- a/src/main/java/io/quacker/domain/user/service/UserService.java
+++ b/src/main/java/io/quacker/domain/user/service/UserService.java
@@ -266,32 +266,55 @@ public class UserService {
 
     /**
      * REQ_011	프로필 조회
-     * 나의 프로필 조회
+     * 특정 공개 사용자 조회,
+     * @param userId, Long
      * @return UserDto
      */
-    public UserDto getUserProfile() {
-        return UserDto.from(getCurrentUser());
+    public UserDto getUserById(Long userId) {
+        var user = userRepository.findById(userId)
+                .orElseThrow(()-> new CustomException("유저를 찾을 수 없음", HttpStatus.BAD_REQUEST.value()));
+
+        // 본인이 아니고 비공개라면
+        if (user.isPrivate() && !userId.equals(user.getId()))
+            throw new CustomException("비공개 유저", HttpStatus.FORBIDDEN.value());
+
+        return UserDto.from(user);
     }
-//
-//    /**a
-//     * REQ_011	프로필 조회
-//     * 특정 사용자 조회
-//     * @param userId, Long
-//     * @return UserDto
-//     */
-//    public UserDto getUserById(Long userId) {
-//        return UserDto.from(userRepository.findById(userId)
-//                .orElseThrow(()-> new CustomException("유저를 찾을 수 없음", 404)));
-//    }
-//
+
+    /**
+     * 토큰 소유자 확인
+     * @param userId,
+     * @return  userId가 현재 인증된 유저와 일치하는지 확인합니다.
+     */
+    public boolean isOwner(Long userId) {
+        var user = getCurrentUser();
+        return user.getId().equals(userId);
+    }
+
     /**
      * REQ_012	프로필 수정
-     * 나의 프로필 수정
+     * 본인 프로필 수정
+     * @param userId, Long
      * @param dto, UserUpdateDto
      * @return UserDto
      */
-    public UserDto updateUserProfile(UserUpdateDto dto) {
-        var user = getCurrentUser();
+    public UserDto updateMyProfile(Long userId, UserUpdateDto dto) {
+        if (!isOwner(userId)) {
+            throw new CustomException("권한없음", HttpStatus.FORBIDDEN.value());
+        }
+        return updateProfile(userId, dto);
+    }
+
+    /**
+     * REQ_012	프로필 수정
+     * 특정 프로필 수정
+     * @param userId, Long
+     * @param dto, UserUpdateDto
+     * @return UserDto
+     */
+    public UserDto updateProfile(Long userId, UserUpdateDto dto) {
+        var user = userRepository.findById(userId)
+                .orElseThrow(()-> new CustomException("유저를 찾을 수 없음", 404));
         user.updateProfile(
                 dto.name(),
                 dto.bio(),
@@ -302,27 +325,6 @@ public class UserService {
 
         return UserDto.from(user);
     }
-//
-//    /**
-//     * REQ_012	프로필 수정
-//     * 특정 프로필 수정
-//     * @param userId, Long
-//     * @param dto, UserUpdateDto
-//     * @return UserDto
-//     */
-//    public UserDto updateUserProfile(Long userId, UserUpdateDto dto) {
-//        var user = userRepository.findById(userId)
-//                .orElseThrow(()-> new CustomException("유저를 찾을 수 없음", 404));
-//        user.updateProfile(
-//                dto.name(),
-//                dto.bio(),
-//                dto.avatarImageUrl(),
-//                dto.isLocked(),
-//                dto.isPrivate()
-//        );
-//
-//        return UserDto.from(user);
-//    }
 
     /**
      * REQ_013	공개여부 토글
@@ -356,10 +358,7 @@ public class UserService {
         }
 
         user.setVerified(true);
-
-        /**
-         * ROLE 변경
-         */
+        //ROLE 변경? 불필요 어차피 이 요청이 끝나고 다시 인증객체가 생성되므로
 
         return true;
     }

--- a/src/main/java/io/quacker/domain/user/service/UserService.java
+++ b/src/main/java/io/quacker/domain/user/service/UserService.java
@@ -137,6 +137,7 @@ public class UserService {
 
         // 토큰 Dto 반환
         return JwtTokens.builder()
+                .userId(user.getId())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();

--- a/src/main/java/io/quacker/global/config/EmailConfig.java
+++ b/src/main/java/io/quacker/global/config/EmailConfig.java
@@ -3,7 +3,7 @@ package io.quacker.global.config;
 import io.quacker.common.dao.EmailCodeRepository;
 import io.quacker.domain.user.service.EmailCodeService;
 import io.quacker.domain.user.service.EmailCodeServiceImpl;
-import io.quacker.domain.user.service.EmailServiceStub;
+import io.quacker.domain.user.service.EmailCodeServiceStub;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -17,17 +17,19 @@ public class EmailConfig {
     private final JavaMailSender mailSender;
     private final EmailCodeRepository emailCodeRepository;
 
-//    @Bean
-//    public EmailCodeService emailService() {
-//        return new EmailServiceStub();
-//    }
-
     @Bean
-    public EmailCodeService emailCodeService(
-            JavaMailSender mailSender,
+    public EmailCodeService emailService(
             EmailCodeRepository emailCodeRepository,
-            @Value("${email-code.expiration}") Long CODE_EXPIRATION_TIME
-    ) {
-        return new EmailCodeServiceImpl(mailSender, emailCodeRepository, CODE_EXPIRATION_TIME);
+            @Value("${email-code.expiration}") Long CODE_EXPIRATION_TIME) {
+        return new EmailCodeServiceStub(emailCodeRepository, CODE_EXPIRATION_TIME);
     }
+
+//    @Bean
+//    public EmailCodeService emailCodeService(
+//            JavaMailSender mailSender,
+//            EmailCodeRepository emailCodeRepository,
+//            @Value("${email-code.expiration}") Long CODE_EXPIRATION_TIME
+//    ) {
+//        return new EmailCodeServiceImpl(mailSender, emailCodeRepository, CODE_EXPIRATION_TIME);
+//    }
 }

--- a/src/main/java/io/quacker/global/config/EmailConfig.java
+++ b/src/main/java/io/quacker/global/config/EmailConfig.java
@@ -1,0 +1,33 @@
+package io.quacker.global.config;
+
+import io.quacker.common.dao.EmailCodeRepository;
+import io.quacker.domain.user.service.EmailCodeService;
+import io.quacker.domain.user.service.EmailCodeServiceImpl;
+import io.quacker.domain.user.service.EmailServiceStub;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@Configuration
+@RequiredArgsConstructor
+public class EmailConfig {
+
+    private final JavaMailSender mailSender;
+    private final EmailCodeRepository emailCodeRepository;
+
+//    @Bean
+//    public EmailCodeService emailService() {
+//        return new EmailServiceStub();
+//    }
+
+    @Bean
+    public EmailCodeService emailCodeService(
+            JavaMailSender mailSender,
+            EmailCodeRepository emailCodeRepository,
+            @Value("${email-code.expiration}") Long CODE_EXPIRATION_TIME
+    ) {
+        return new EmailCodeServiceImpl(mailSender, emailCodeRepository, CODE_EXPIRATION_TIME);
+    }
+}

--- a/src/main/java/io/quacker/global/config/RedisConfig.java
+++ b/src/main/java/io/quacker/global/config/RedisConfig.java
@@ -1,12 +1,15 @@
 package io.quacker.global.config;
 
+import io.quacker.common.dao.EmailCodeRepository;
 import io.quacker.common.dao.JwtRepository;
 import io.quacker.common.dao.UserDeletionRepository;
 import io.quacker.domain.auth.dao.MemoryJwtRepository;
+import io.quacker.domain.user.dao.MemoryEmailCodeRepository;
 import io.quacker.domain.user.dao.MemoryUserDeletionRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+// 임시 레디스 빈설정
 @Configuration
 public class RedisConfig {
 
@@ -20,4 +23,10 @@ public class RedisConfig {
     public UserDeletionRepository userDeletionRepository() {
         return new MemoryUserDeletionRepository();
     }
+
+    @Bean
+    public EmailCodeRepository emailCodeRepository() {
+        return new MemoryEmailCodeRepository();
+    }
+
 }

--- a/src/main/java/io/quacker/global/config/SecurityConfig.java
+++ b/src/main/java/io/quacker/global/config/SecurityConfig.java
@@ -36,8 +36,8 @@ public class SecurityConfig {
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))  // iframe 허용하기 위하여
                 .authorizeHttpRequests(auth -> auth
                                 .requestMatchers("/h2-console/**").permitAll() // H2 Console 접근 허용                                .anyRequest().authenticated()
-                                .requestMatchers("/api/v1/auth/login", "/api/v1/auth/join", "/api/v1/auth/refresh").permitAll()
                                 .requestMatchers("/api/v1/auth/logout").authenticated()
+                                .requestMatchers("/api/v1/auth/**").permitAll()
                                 .anyRequest().authenticated()
 //                                .anyRequest().permitAll()
                 )


### PR DESCRIPTION
### 📄 작업 내용

- 이메일 인증 구현
- 비밀번호 재설정
- 계정 삭제요청(소프트)
- ROLE 추가
- 콘솔로그로 인증코드를 출력하는 이메일서비스stub 적용

### 🌠 스크린샷

-  ![image](https://github.com/user-attachments/assets/c62dd03c-6562-4ef1-b9ed-8769b0187751)
- ![image](https://github.com/user-attachments/assets/51b9f7f5-9dcb-4b7f-b4bd-f0f00f2f06c7)



### 📌 이슈 링크

- [작업에 대한 이슈 링크를 남겨주세요 ](https://quacker25.atlassian.net/browse/QUAC-7?atlOrigin=eyJpIjoiNTNlMDVhYTBiMzU3NDI0OWI3MTMwOGE5YWJmOGIxM2UiLCJwIjoiaiJ9)


### 📚 앞으로의 과제

- 스웨거 적용과 테스트코드작성 후 리펙토링이 필요합니다.