### PR TITLE
Feat/quac 31 mention 기능 구현

### DIFF
--- a/src/main/java/io/quacker/domain/post/entity/Post.java
+++ b/src/main/java/io/quacker/domain/post/entity/Post.java
@@ -2,26 +2,34 @@ package io.quacker.domain.post.entity;
 
 import io.quacker.common.entity.BaseEntity;
 import io.quacker.domain.comment.entity.Comment;
+import io.quacker.domain.hashtag.entity.Hashtag;
 import io.quacker.domain.hashtagpost.entity.HashtagPost;
 import io.quacker.domain.postimage.entity.PostImage;
 import io.quacker.domain.postlike.entity.PostLike;
 import io.quacker.domain.postmention.entity.PostMention;
 import io.quacker.domain.user.entity.User;
-import io.quacker.domain.hashtag.entity.Hashtag;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
-import java.beans.Transient;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -79,12 +87,16 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post")
     private List<PostLike> likes = new ArrayList<>();
 
-    /** ✅ 리트윗 수 증가 */
+    /**
+     * ✅ 리트윗 수 증가
+     */
     public void incrementRepostCount() {
         this.repostCount++;
     }
 
-    /** ✅ 리트윗 수 감소 */
+    /**
+     * ✅ 리트윗 수 감소
+     */
     public void decrementRepostCount() {
         if (this.repostCount > 0) {
             this.repostCount--;
@@ -138,10 +150,13 @@ public class Post extends BaseEntity {
         return hashtagPosts;
     }
 
-    public Set<Hashtag> getHashtags() {
-        return this.hashtagPosts.stream()
-                .map(HashtagPost::getHashtag)
-                .collect(java.util.stream.Collectors.toSet());
+    public void addPostMention(PostMention postMention) {
+        postMention.setPost(this);
     }
 
+    public Set<Hashtag> getHashtags() {
+        return this.hashtagPosts.stream()
+            .map(HashtagPost::getHashtag)
+            .collect(java.util.stream.Collectors.toSet());
+    }
 }

--- a/src/main/java/io/quacker/domain/post/entity/Post.java
+++ b/src/main/java/io/quacker/domain/post/entity/Post.java
@@ -82,6 +82,7 @@ public class Post extends BaseEntity {
     private List<PostImage> postImages = new ArrayList<>();
 
     @OneToMany(mappedBy = "post")
+    @Builder.Default
     private List<PostMention> postMentions = new ArrayList<>();
 
     @OneToMany(mappedBy = "post")
@@ -151,7 +152,7 @@ public class Post extends BaseEntity {
     }
 
     public void addPostMention(PostMention postMention) {
-        postMention.setPost(this);
+        this.getPostMentions().add(postMention);
     }
 
     public Set<Hashtag> getHashtags() {

--- a/src/main/java/io/quacker/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/io/quacker/domain/post/service/impl/PostServiceImpl.java
@@ -1,29 +1,29 @@
 package io.quacker.domain.post.service.impl;
 
-import io.quacker.domain.post.dto.PostCreateRequestDto;
-import io.quacker.domain.post.dto.PostUpdateRequestDto;
-import io.quacker.domain.post.vo.SortBy;
 import io.quacker.domain.hashtag.service.HashtagService;
 import io.quacker.domain.post.dao.PostRepository;
+import io.quacker.domain.post.dto.PostCreateRequestDto;
 import io.quacker.domain.post.dto.PostDto;
+import io.quacker.domain.post.dto.PostUpdateRequestDto;
 import io.quacker.domain.post.entity.Post;
 import io.quacker.domain.post.service.PostService;
+import io.quacker.domain.post.vo.SortBy;
 import io.quacker.domain.postimage.dao.PostImageRepository;
 import io.quacker.domain.postimage.service.PostImageService;
+import io.quacker.domain.postmention.service.PostMentionService;
+import io.quacker.domain.user.dao.UserRepository;
 import io.quacker.domain.user.entity.User;
 import io.quacker.domain.user.service.UserService;
 import io.quacker.global.exception.CustomException;
 import io.quacker.global.service.FileUploadService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import io.quacker.domain.user.dao.UserRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -37,19 +37,20 @@ public class PostServiceImpl implements PostService {
     private final PostImageService postImageService;
     private final FileUploadService fileUploadService;
     private final HashtagService hashtagService;
+    private final PostMentionService postMentionService;
 
     // 모든 게시물 조회
     @Override
     public Page<PostDto> getAllPosts(SortBy sortBy, Pageable pageable) {
         return postRepository.findAll(getSortedPageable(pageable, sortBy))
-                .map(PostDto::from);
+            .map(PostDto::from);
     }
 
     // 특정 게시물 상세 조회
     @Override
     public PostDto getPost(Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new CustomException("게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()));
+            .orElseThrow(() -> new CustomException("게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()));
         return PostDto.from(post);
     }
 
@@ -60,7 +61,7 @@ public class PostServiceImpl implements PostService {
         User user = userService.getCurrentUser();
 
         return postRepository.findByUser(user, getSortedPageable(pageable, sortBy))
-                .map(PostDto::from);
+            .map(PostDto::from);
 
     }
 
@@ -68,7 +69,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public Page<PostDto> searchPosts(String keyword, SortBy sortBy, Pageable pageable) {
         return postRepository.findByTextContainingIgnoreCase(keyword, getSortedPageable(pageable, sortBy))
-                .map(PostDto::from);
+            .map(PostDto::from);
     }
 
     // 새 게시글 작성
@@ -77,26 +78,27 @@ public class PostServiceImpl implements PostService {
         User user = userService.getCurrentUser();
 
         Post newPost = Post.builder()
-                .text(request.text())
-                .user(user)
-                .build();
+            .text(request.text())
+            .user(user)
+            .build();
 
         // 먼저 Post 저장
         Post savedPost = postRepository.save(newPost);
+        postMentionService.addPostMention(savedPost);
 
         // 이미지가 있는 경우 처리
         if (request.images() != null && !request.images().isEmpty()) {
             List<String> imageUrls = request.images().stream()
-                    .limit(4) // 최대 4개 제한
-                    .map(fileUploadService::uploadImage) // S3에 업로드
-                    .toList();
+                .limit(4) // 최대 4개 제한
+                .map(fileUploadService::uploadImage) // S3에 업로드
+                .toList();
 
             postImageService.saveImagesByUrls(imageUrls, savedPost);
         }
-        
+
         // 해시태그 처리
         hashtagService.updatePostHashtags(savedPost, request.text());
-        
+
         return PostDto.from(savedPost);
     }
 
@@ -105,15 +107,15 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public PostDto repost(Long postId, PostDto postDto) {
         Post originPost = postRepository.findById(postId)
-                .orElseThrow(() -> new CustomException("원본 게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()));
+            .orElseThrow(() -> new CustomException("원본 게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()));
 
         User user = userService.getCurrentUser();
 
         Post retweet = Post.builder()
-                .text(postDto.text() == null ? "" : postDto.text()) // 리트윗은 내용이 없을 수도 있음
-                .user(user)
-                .originPost(originPost)
-                .build();
+            .text(postDto.text() == null ? "" : postDto.text()) // 리트윗은 내용이 없을 수도 있음
+            .user(user)
+            .originPost(originPost)
+            .build();
 
         originPost.incrementRepostCount(); // 원본 게시글의 repostCount 증가
         postRepository.save(originPost); // 명시적으로 저장
@@ -130,7 +132,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public PostDto updatePost(Long postId, PostUpdateRequestDto request) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new CustomException("게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()));
+            .orElseThrow(() -> new CustomException("게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()));
 
         // 텍스트 수정
         post.updateText(request.text());
@@ -149,8 +151,8 @@ public class PostServiceImpl implements PostService {
             }
 
             List<String> newImageUrls = request.newImages().stream()
-                    .map(fileUploadService::uploadImage)
-                    .toList();
+                .map(fileUploadService::uploadImage)
+                .toList();
 
             postImageService.saveImagesByUrls(newImageUrls, post);
         }
@@ -166,11 +168,11 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public boolean deletePost(Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new CustomException("게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()));
+            .orElseThrow(() -> new CustomException("게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()));
 
         // 해시태그 처리
         hashtagService.handlePostDeletion(post);
-        
+
         postRepository.delete(post);
         return true;
     }
@@ -183,9 +185,9 @@ public class PostServiceImpl implements PostService {
     //  페이징 메서드
     private Pageable getSortedPageable(Pageable pageable, SortBy sortBy) {
         return PageRequest.of(
-                pageable.getPageNumber(),
-                pageable.getPageSize(),
-                sortBy.getSort()
+            pageable.getPageNumber(),
+            pageable.getPageSize(),
+            sortBy.getSort()
         );
     }
 

--- a/src/main/java/io/quacker/domain/postlike/service/PostLikeService.java
+++ b/src/main/java/io/quacker/domain/postlike/service/PostLikeService.java
@@ -32,7 +32,7 @@ public class PostLikeService {
         boolean isLiked = postLikeRepository.findByPostAndUser(post, user)
                 .map(like -> {
                     postLikeRepository.delete(like);
-                    post.decrementLikeCount();
+                    post.decreaseLikeCount();
                     return false;
                 })
                 .orElseGet(() -> {
@@ -41,7 +41,7 @@ public class PostLikeService {
                             .user(user)
                             .build();
                     postLikeRepository.save(newLike);
-                    post.incrementLikeCount();
+                    post.increaseLikeCount();
                     return true;
                 });
 

--- a/src/main/java/io/quacker/domain/postmention/controller/PostMentionController.java
+++ b/src/main/java/io/quacker/domain/postmention/controller/PostMentionController.java
@@ -1,0 +1,22 @@
+package io.quacker.domain.postmention.controller;
+
+import io.quacker.domain.postmention.service.PostMentionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+public class PostMentionController {
+
+    private final PostMentionService postMentionService;
+
+    @GetMapping("users/{userId}/mentions")
+    public ResponseEntity<?> getPostByMentionUser(@PathVariable Long userId) {
+        return ResponseEntity.ok(postMentionService.getAllMentionPostByUser(userId));
+    }
+}

--- a/src/main/java/io/quacker/domain/postmention/dao/PostMentionRepository.java
+++ b/src/main/java/io/quacker/domain/postmention/dao/PostMentionRepository.java
@@ -1,0 +1,10 @@
+package io.quacker.domain.postmention.dao;
+
+import io.quacker.domain.postmention.entity.PostMention;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostMentionRepository extends JpaRepository<PostMention, Long> {
+
+    List<PostMention> findByUserId(Long userId);
+}

--- a/src/main/java/io/quacker/domain/postmention/entity/PostMention.java
+++ b/src/main/java/io/quacker/domain/postmention/entity/PostMention.java
@@ -10,8 +10,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class PostMention extends BaseEntity {
 
     @Id
@@ -25,4 +27,15 @@ public class PostMention extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_ID")
     private User user;
+
+    public void setPost(Post post) {
+        this.post = post;
+        post.addPostMention(this);
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+        user.addPostMention(this);
+    }
+
 }

--- a/src/main/java/io/quacker/domain/postmention/service/PostMentionService.java
+++ b/src/main/java/io/quacker/domain/postmention/service/PostMentionService.java
@@ -1,0 +1,69 @@
+package io.quacker.domain.postmention.service;
+
+import io.quacker.domain.post.dto.PostDto;
+import io.quacker.domain.post.entity.Post;
+import io.quacker.domain.postmention.dao.PostMentionRepository;
+import io.quacker.domain.postmention.entity.PostMention;
+import io.quacker.domain.user.dao.UserRepository;
+import io.quacker.domain.user.entity.User;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostMentionService {
+
+    private static final Pattern HASHTAG_PATTERN = Pattern.compile("@([가-힣a-zA-Z0-9_]+)(?=\\s|$)");
+    private final UserRepository userRepository;
+    private final PostMentionRepository postMentionRepository;
+
+    @Transactional
+    public void addPostMention(Post post) {
+        List<String> usernames = extractMentionUserNames(post.getText());
+        List<User> users = findMentionsUsers(usernames);
+
+        for (User user : users) {
+            PostMention postMention = new PostMention();
+            postMention.setPost(post);
+            postMention.setUser(user);
+            postMentionRepository.save(postMention);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostDto> getAllMentionPostByUser(Long userId) {
+        List<PostMention> postMentions = postMentionRepository.findByUserId(userId);
+        List<Post> posts = postMentions.stream().map(PostMention::getPost).toList();
+
+        return posts.stream().map(PostDto::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<User> findMentionsUsers(List<String> userNames) {
+        List<User> users = new ArrayList<>();
+
+        for (String name : userNames) {
+            Optional<User> findUser = userRepository.findByName(name);
+            findUser.ifPresent(users::add);
+        }
+
+        return users;
+    }
+
+    private List<String> extractMentionUserNames(String content) {
+        List<String> mentionUserName = new ArrayList<>();
+        Matcher matcher = HASHTAG_PATTERN.matcher(content);
+
+        while (matcher.find()) {
+            mentionUserName.add(matcher.group());
+        }
+
+        return mentionUserName;
+    }
+}

--- a/src/main/java/io/quacker/domain/postmention/service/PostMentionService.java
+++ b/src/main/java/io/quacker/domain/postmention/service/PostMentionService.java
@@ -28,10 +28,14 @@ public class PostMentionService {
         List<String> usernames = extractMentionUserNames(post.getText());
         List<User> users = findMentionsUsers(usernames);
 
+        System.out.println(usernames);
+        System.out.println(users);
+
         for (User user : users) {
             PostMention postMention = new PostMention();
             postMention.setPost(post);
             postMention.setUser(user);
+            System.out.println("tlqkf");
             postMentionRepository.save(postMention);
         }
     }
@@ -61,7 +65,7 @@ public class PostMentionService {
         Matcher matcher = HASHTAG_PATTERN.matcher(content);
 
         while (matcher.find()) {
-            mentionUserName.add(matcher.group());
+            mentionUserName.add(matcher.group().replace("@", ""));
         }
 
         return mentionUserName;

--- a/src/main/java/io/quacker/domain/user/dao/UserRepository.java
+++ b/src/main/java/io/quacker/domain/user/dao/UserRepository.java
@@ -2,10 +2,10 @@ package io.quacker.domain.user.dao;
 
 
 import io.quacker.domain.user.entity.User;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -17,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByName(String name);
 
     Optional<User> findByHint(String hint);
+
+    Optional<User> findByName(String name);
 }

--- a/src/main/java/io/quacker/domain/user/entity/User.java
+++ b/src/main/java/io/quacker/domain/user/entity/User.java
@@ -14,13 +14,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -82,27 +83,33 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user")
     private List<PostLike> likes = new ArrayList<>();
 
+    public static User fromCreateDtoWithHashedPassword(UserCreateDto userCreateDto,
+                                                       String hashedPw) {
+        return User.builder()
+            .email(userCreateDto.email())
+            .password(hashedPw)
+            .name(userCreateDto.name())
+            .bio(userCreateDto.bio())
+            .avatarImageUrl(userCreateDto.avatarImageUrl())
+            .isPrivate(userCreateDto.isPrivate())
+            .isVerified(false)
+            .build();
+    }
+
     public void updateVisibility(boolean isPrivate) {
         this.isPrivate = isPrivate;
     }
 
-    public void freeze() { this.isLocked = false; }
-
-    public void unfreeze() { this.isLocked = true; }
-
-    public static User fromCreateDtoWithHashedPassword(UserCreateDto userCreateDto, String hashedPw) {
-        return User.builder()
-                .email(userCreateDto.email())
-                .password(hashedPw)
-                .name(userCreateDto.name())
-                .bio(userCreateDto.bio())
-                .avatarImageUrl(userCreateDto.avatarImageUrl())
-                .isPrivate(userCreateDto.isPrivate())
-                .isVerified(false)
-                .build();
+    public void freeze() {
+        this.isLocked = false;
     }
 
-    public void updateProfile(String name, String bio, String avatarImageUrl, boolean isLocked, boolean isPrivate) {
+    public void unfreeze() {
+        this.isLocked = true;
+    }
+
+    public void updateProfile(String name, String bio, String avatarImageUrl, boolean isLocked,
+                              boolean isPrivate) {
         this.name = name;
         this.bio = bio;
         this.avatarImageUrl = avatarImageUrl;
@@ -114,5 +121,8 @@ public class User extends BaseEntity {
         this.password = password;
     }
 
+    public void addPostMention(PostMention postMention) {
+        this.postMentions.add(postMention);
+    }
 }
 


### PR DESCRIPTION
### 📄 작업 내용

- Post 등록시에 mention 된 user 파싱 및 데이터 베이스 저장 기능 구현
- user의 멘션된 post 조회 가능 구현

### 🌠 스크린샷

-  mention된 post 목록 조회

<img width="500" alt="스크린샷 2025-03-27 오후 11 04 59" src="https://github.com/user-attachments/assets/793fa483-e0b9-4234-8a54-3d16264c4344" />

### 📌 이슈 링크

- [Jira](https://quacker25.atlassian.net/browse/QUAC-31)


### 📚 앞으로의 과제

- ci/cd 파이프 라인 구현 및 배포