### PR TITLE
fix : 토큰에 따른 필터 검증로직 변경(기존 url)

### DIFF
--- a/src/main/java/io/quacker/domain/admin/service/AdminService.java
+++ b/src/main/java/io/quacker/domain/admin/service/AdminService.java
@@ -136,7 +136,7 @@ public class AdminService {
 
         // 토큰 재발급
         // TODO 토큰 발급로직 일반화 할 것
-        String newAccessToken = jwtTokenUtil.generateAccessToken(admin.getId(), admin.getUsername(), admin.getUsername());
+        String newAccessToken = jwtTokenUtil.generateAccessToken(admin.getId(), admin.getUsername(), "admin");
         String newRefreshToken = jwtTokenUtil.generateRefreshToken(admin.getId());
 
         // 토큰 Dto 반환

--- a/src/main/java/io/quacker/global/security/JwtAdminAuthenticationFilter.java
+++ b/src/main/java/io/quacker/global/security/JwtAdminAuthenticationFilter.java
@@ -37,11 +37,12 @@ public class JwtAdminAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
 
         // 허용된 URI는 인증시도 하지않음
-        String uri = request.getRequestURI();
-        if (!uri.startsWith("/api/v1/admins")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+        // 추후 admin과 user이 도메인 분리된다면 사용할 것
+//        String uri = request.getRequestURI();
+//        if (!uri.startsWith("/api/v1/admins")) {
+//            filterChain.doFilter(request, response);
+//            return;
+//        }
 
 
         // 인증 헤더 추출
@@ -64,6 +65,12 @@ public class JwtAdminAuthenticationFilter extends OncePerRequestFilter {
 
         // 사용자 email(username) 추출
         String username = jwtTokenUtil.extractEmail(token);
+
+        // 어드민 토큰이 아니라면
+        if (!jwtTokenUtil.extractRole(token).equals("admin")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         // 새 토큰 발급, when 유저이름이 존재하지않고 현재 SecurityContext에 인증 정보가 없는 경우
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {


### PR DESCRIPTION
### 📄 작업 내용

- Admin필터가 user필터보다 앞에 존재합니다.
- Admin필터는 admins 경로로 요청이 들어올때만 해당 필터를 사용하였습니다.
- 그럼 일반 도메인의 PreAuthorize(hasAuthority('ROLE_ADMIN'))을 사용하지 못하게 됩니다.
- 토큰의 role 클레임으로 필터를 선택하게 변경하였습니다.

### 🌠 스크린샷

-  작업물에 대한 스크린샷을 첨부해주세요 (ex. Postman, 테스트 코드 통과)

### 📌 이슈 링크

- 작업에 대한 이슈 링크를 남겨주세요 


### 📚 앞으로의 과제

- 다음에 작업할 과제를 남겨주세요